### PR TITLE
Make dynamic svg images appear in screenshots

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+browser.build.js

--- a/controller.js
+++ b/controller.js
@@ -32,6 +32,10 @@ function getUniqueUrls(urls) {
   return urls;
 }
 
+function ampersands(string) {
+  return string.replace(/&/g, '&amp;');
+}
+
 async function downloadCSSContent(blocks) {
   const promises = blocks.map(async block => {
     if (block.href) {
@@ -146,6 +150,14 @@ Docs:
         globalCSS = globalCSS.split(url.url).join(url.name);
         this.snapshots.forEach(snapshot => {
           snapshot.html = snapshot.html.split(url.url).join(url.name);
+          if (/&/.test.snapshot.url) {
+            // When URL has an ampersand, we need to make sure the html wasn't
+            // escaped so we replace again, this time with "&" replaced by
+            // "&amp;"
+            snapshot.html = snapshot.html
+              .split(ampersands(url.url))
+              .join(url.name);
+          }
         });
       }
     }


### PR DESCRIPTION
This commit fixes two things:
- When svg images are part of an asset package, the hash url needs to
  have a file suffix for Happo to show it
- Dynamic asset paths (i.e. containing query params) weren't injected in
  the DOM snapshot html correctly.

The former issue I fixed by mapping the fetched content type to a file
suffix. This is for svg files mainly but I thought it would be to have
all images get the suffix.

The latter issue was fixed by ampersanding "&" before injecting the new
url in the html.