### PR TITLE
Add support for buffer images

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "base64-stream": "^1.0.0",
     "crypto-js": "^4.1.1",
     "https-proxy-agent": "^5.0.0",
+    "image-size": "^1.0.1",
     "mkdirp": "^1.0.4",
     "node-fetch": "^2.0.0",
     "parse-srcset": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1429,6 +1429,13 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+image-size@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.1.tgz#86d6cfc2b1d19eab5d2b368d4b9194d9e48541c5"
+  integrity sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==
+  dependencies:
+    queue "6.0.2"
+
 imagetracerjs@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/imagetracerjs/-/imagetracerjs-1.2.6.tgz#1f618b9b94b6f298145ce9cb5e74a88447f15184"
@@ -2215,6 +2222,13 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.1.0"


### PR DESCRIPTION
Before, the only way you could upload images was via a path to a file in
the file system. When exploring Appium integrations
(https://github.com/happo/happo-appium) I noticed that we get base64
encoded buffers instead. So to avoid having to save a buffer to file
first, I'm making registerLocalSnapshot and uploadImage work with
buffers as well.

If the width and height is provided and you provide a buffer, we will
now also compute the dimensions on the fly for you.