### PR TITLE
Handle asset urls before recording outer html

### DIFF
--- a/takeDOMSnapshot.js
+++ b/takeDOMSnapshot.js
@@ -216,11 +216,12 @@ function takeDOMSnapshot({
     doc.activeElement.setAttribute('data-happo-focus', 'true');
   }
 
-  const html = element.outerHTML;
   const assetUrls = getElementAssetUrls(element, {
     doc,
     handleBase64Image,
   });
+
+  const html = element.outerHTML;
   const cssBlocks = extractCSSBlocks(doc);
   const htmlElementAttrs = extractElementAttributes(doc.documentElement);
   const bodyElementAttrs = extractElementAttributes(doc.body);


### PR DESCRIPTION
the getElementAssetUrls can in some cases modify the DOM. If we record the html before calling getElementAssetUrls the modifications done are lost.

Modifications can happen for inlined canvases, as it does in the default handleBase64Image.