### PR TITLE
Fix including assets when url is a localhost url

### DIFF
--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -82,8 +82,9 @@ module.exports = function createAssetPackage(urls) {
 
     const promises = urls.map(async item => {
       const { url, baseUrl } = item;
-      const isExternalUrl = /^https?:/.test(url || '');
-      if (!HAPPO_DOWNLOAD_ALL && isExternalUrl) {
+      const isExternalUrl = /^https?:/.test(url);
+      const isLocalhost = /\/\/(localhost|127\.0\.0\.1)(:|\/)/.test(url);
+      if (!HAPPO_DOWNLOAD_ALL && isExternalUrl && !isLocalhost) {
         return;
       }
       const isDynamic = url.indexOf('?') > 0;

--- a/test/createAssetPackage-test.js
+++ b/test/createAssetPackage-test.js
@@ -5,7 +5,7 @@ const createAssetPackage = require('../src/createAssetPackage');
 
 const { SAVE_PACKAGE } = process.env;
 
-async function runBasicTest() {
+async function wrap(func) {
   const handler = require('serve-handler');
   const http = require('http');
 
@@ -21,13 +21,7 @@ async function runBasicTest() {
   });
 
   try {
-    const pkg = await createAssetPackage([
-      {
-        url: '/sub%20folder/countries-bg.jpeg',
-        baseUrl: 'http://localhost:3412',
-      },
-    ]);
-    assert.equal(pkg.hash, 'aed32b1cc82366d461b7755d5eb3f13a');
+    const pkg = await func();
     if (SAVE_PACKAGE) {
       fs.writeFileSync('test-package.zip', pkg.buffer);
     }
@@ -36,8 +30,35 @@ async function runBasicTest() {
   }
 }
 
+async function runBasicTest() {
+  await wrap(async () => {
+    const pkg = await createAssetPackage([
+      {
+        url: '/sub%20folder/countries-bg.jpeg',
+        baseUrl: 'http://localhost:3412',
+      },
+    ]);
+    assert.equal(pkg.hash, '558b9f58b427a127a271719fb27e0141');
+    return pkg;
+  });
+}
+
+async function runLocalhostTest() {
+  await wrap(async () => {
+    const pkg = await createAssetPackage([
+      {
+        url: 'http://localhost:3412/sub%20folder/countries-bg.jpeg',
+        baseUrl: 'http://localhost:3412',
+      },
+    ]);
+    assert.equal(pkg.hash, '4b2ca8574350a846230c60b21bc2058f');
+    return pkg;
+  });
+}
+
 async function runTest() {
   await runBasicTest();
+  await runLocalhostTest();
 }
 
 runTest()


### PR DESCRIPTION
If we encountered an asset with url e.g.
http://localhost:3000/foo/bar.jpg we would assume it's an external one that Happo's workers can access directly.

To fix this, I'm adding some code that will make sure that localhost/127.0.0.1 urls are automatically fetched and added as "/_external" assets.