### PR TITLE
Allow multiple elements in takeDOMSnapshot.js

### DIFF
--- a/test/takeDOMSnapshot-test.js
+++ b/test/takeDOMSnapshot-test.js
@@ -54,9 +54,29 @@ function runFocusTest() {
   `.trim());
 }
 
+function runMultiElementTest() {
+  const { JSDOM } = jsdom;
+  const dom = new JSDOM(`
+<!DOCTYPE html>
+<html>
+  <body>
+  <button>Hello</button>
+  <button>World</button>
+  </body>
+</html>
+  `);
+  const { document: doc } = dom.window;
+  const element = doc.querySelectorAll('button');
+  let snapshot = takeDOMSnapshot({ doc, element });
+  assert.equal(snapshot.html.trim(), `
+  <button>Hello</button>\n<button>World</button>
+  `.trim());
+}
+
 function runTest() {
   runBasicTest();
   runFocusTest();
+  runMultiElementTest();
 }
 
 runTest();


### PR DESCRIPTION
This commit addresses an issue where all elements matching a selector should be included in a screenshot. Specifically, this time it's a header where certain elements are rendered in a "portal" outside of some element. By allowing a new option passed in happo-cypress, "includeAllElements: true", we can send an array of elements to happo-e2e, and takeDOMSnapshot.js will then combine html for all matches in a single "package".