### PR TITLE
Handle merge_group events in resolveEnvironment.js

### DIFF
--- a/src/resolveEnvironment.js
+++ b/src/resolveEnvironment.js
@@ -74,6 +74,9 @@ function resolveLink(env) {
     if (ghEvent.head_commit) {
       return ghEvent.head_commit.url;
     }
+    if (ghEvent.merge_group) {
+      return `${ghEvent.repository.html_url}/commit/${ghEvent.merge_group.head_sha}`;
+    }
     if (GITHUB_SHA && ghEvent.repository) {
       return `${ghEvent.repository.html_url}/commit/${GITHUB_SHA}`;
     }
@@ -206,6 +209,9 @@ function resolveBeforeSha(env, afterSha) {
     if (ghEvent.pull_request) {
       return ghEvent.pull_request.base.sha;
     }
+    if (ghEvent.merge_group) {
+      return ghEvent.merge_group.base_sha;
+    }
     return ghEvent.before;
   }
 
@@ -276,6 +282,9 @@ function resolveAfterSha(env) {
     const ghEvent = require(GITHUB_EVENT_PATH);
     if (ghEvent.pull_request) {
       return ghEvent.pull_request.head.sha;
+    }
+    if (ghEvent.merge_group) {
+      return ghEvent.merge_group.head_sha;
     }
     return ghEvent.after || GITHUB_SHA;
   }

--- a/test/github_merge_group_event.json
+++ b/test/github_merge_group_event.json
@@ -1,0 +1,9 @@
+{
+  "merge_group": {
+    "head_sha": "ec26c3e57ca3a959ca5aad62de7213c562f8c821",
+    "base_sha": "f95f852bd8fca8fcc58a9a2d6c842781e32a215e"
+  },
+  "repository": {
+    "html_url": "https://github.com/Codertocat/Hello-World"
+  }
+}

--- a/test/resolveEnvironment-test.js
+++ b/test/resolveEnvironment-test.js
@@ -159,6 +159,21 @@ function testGithubActionsEnvironment() {
   assert.ok(result.message !== undefined);
 }
 
+function testGithubMergeGroupEnvironment() {
+  const githubEnv = {
+    GITHUB_SHA: 'ccddffddccffdd',
+    GITHUB_EVENT_PATH: path.resolve(
+      __dirname,
+      'github_merge_group_event.json',
+    ),
+  };
+  let result = resolveEnvironment(githubEnv);
+  assert.equal(result.beforeSha, 'f95f852bd8fca8fcc58a9a2d6c842781e32a215e');
+  assert.equal(result.afterSha, 'ec26c3e57ca3a959ca5aad62de7213c562f8c821');
+  assert.equal(result.link, 'https://github.com/Codertocat/Hello-World/commit/ec26c3e57ca3a959ca5aad62de7213c562f8c821');
+  assert.ok(result.message !== undefined);
+}
+
 function testTravisEnv() {
   const travisEnv = {
     HAPPO_GITHUB_BASE: 'http://git.hub',
@@ -250,6 +265,7 @@ function testHappoEnv() {
 
 function runTest() {
   testGithubActionsEnvironment();
+  testGithubMergeGroupEnvironment();
   testDevEnv();
   testCircleCIEnv();
   testTravisEnv();


### PR DESCRIPTION
This fixes a bug where the Happo status wouldn't be updated for a commit that was in a merge queue. We mainly need to resolve the base sha in order to get the status check posted.