### PR TITLE
Fix making relative url paths absolute

### DIFF
--- a/src/makeAbsolute.js
+++ b/src/makeAbsolute.js
@@ -4,17 +4,8 @@ module.exports = function makeAbsolute(url, baseUrl) {
   if (url.startsWith('//')) {
     return `${baseUrl.split(':')[0]}:${url}`;
   }
-  if (url.startsWith('/')) {
-    return `${new URL(baseUrl).origin}${url}`;
-  }
   if (/^https?:/.test(url)) {
     return url;
   }
-
-  const parts = [baseUrl];
-  if (!/\/$/.test(baseUrl)) {
-    parts.push('/');
-  }
-  parts.push(url);
-  return new URL(parts.join('')).href;
+  return new URL(url, baseUrl).href;
 };

--- a/test/makeAbsolute-test.js
+++ b/test/makeAbsolute-test.js
@@ -27,6 +27,14 @@ function runTest() {
     'http://goo.bar/bar/foo.png',
   );
   assert.equal(
+    makeAbsolute('../bar/foo.png', 'http://goo.bar/foo/test.html?foo=bar'),
+    'http://goo.bar/bar/foo.png',
+  );
+  assert.equal(
+    makeAbsolute('./bar/foo.png', 'http://goo.bar/foo/test.html?foo=bar#difference'),
+    'http://goo.bar/foo/bar/foo.png',
+  );
+  assert.equal(
     makeAbsolute('/bar/foo.png', 'http://goo.bar/foo/'),
     'http://goo.bar/bar/foo.png',
   );


### PR DESCRIPTION
We found this from a playwright test suite. An image with path ./image.jpg on an element with baseURI
http://localhost:3000/iframe.html would try to download the image from http://localhost:3000/iframe.html?/./image.jpg

We can fix this by making better use of the URL class in node.