### PR TITLE
Add controller.removeDuplicatesInTimeframe function

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -341,6 +341,40 @@ Docs:
     });
   }
 
+  removeDuplicatesInTimeframe({ start, end }) {
+    if (HAPPO_DEBUG) {
+      console.log(
+        `[HAPPO] Removing duplicate snapshots made between ${new Date(
+          start,
+        )} and ${new Date(end)}`,
+      );
+    }
+    const seenSnapshots = {};
+    this.snapshots = this.snapshots.filter(snapshot => {
+      const { timestamp, component, variant } = snapshot;
+      if (!timestamp) {
+        return true;
+      }
+      const id = [component, variant].join('-_|_-');
+      const inTimeframe = timestamp >= start && timestamp <= end;
+      if (inTimeframe) {
+        if (seenSnapshots[id]) {
+          // Found a duplicate made in the timeframe specified
+          if (HAPPO_DEBUG) {
+            console.log(
+              `[HAPPO] Found duplicate snapshot to remove: "${component}", "${variant}" at timestamp ${new Date(
+                timestamp,
+              )}`,
+            );
+          }
+          return false;
+        }
+        seenSnapshots[id] = true;
+      }
+      return true;
+    });
+  }
+
   async processSnapRequestIds(allRequestIds) {
     if (HAPPO_E2E_PORT) {
       // We're running with `happo-cypress --`


### PR DESCRIPTION
This function will be used by happo-cypress to clean up after a retried spec. In Cypress 12 and earlier, we were able to the the start and end of the failed attempt but in Cypress 13 we only get the timestamp for the whole spec execution (including failed attempt + retry). To make the cleanup process simpler, I'm adding a utility function to remove duplicates happening in a specific timeframe.