### PR TITLE
Grab asset urls from <image> tags as well

### DIFF
--- a/takeDOMSnapshot.js
+++ b/takeDOMSnapshot.js
@@ -53,6 +53,7 @@ function getElementAssetUrls(
     }
     const srcset = element.getAttribute('srcset');
     const src = element.getAttribute('src');
+    const href = element.tagName.toLowerCase() === 'image' && element.getAttribute('href');
     const style = element.getAttribute('style');
     const base64Url = element._base64Url;
     if (base64Url) {
@@ -76,6 +77,9 @@ function getElementAssetUrls(
           baseUrl: element.baseURI,
         })),
       );
+    }
+    if (href) {
+      allUrls.push({ url: href, baseUrl: element.baseURI });
     }
   });
   return allUrls.filter(({ url }) => !url.startsWith('data:'));

--- a/test/createAssetPackage-test.js
+++ b/test/createAssetPackage-test.js
@@ -41,7 +41,7 @@ async function runBasicTest() {
     assert.equal(
       pkg.hash,
       process.env.CI
-        ? 'aed32b1cc82366d461b7755d5eb3f13a'
+        ? 'fb8d38b72a5a6f768c529e82b9996c4c'
         : '558b9f58b427a127a271719fb27e0141',
     );
     return pkg;

--- a/test/createAssetPackage-test.js
+++ b/test/createAssetPackage-test.js
@@ -59,7 +59,7 @@ async function runLocalhostTest() {
     assert.equal(
       pkg.hash,
       process.env.CI
-        ? '37d4189cb825c87641f36f9c9222d6ff'
+        ? '5b26f047fbe537d110a1faac00ae1a94'
         : '4b2ca8574350a846230c60b21bc2058f',
     );
     return pkg;

--- a/test/takeDOMSnapshot-test.js
+++ b/test/takeDOMSnapshot-test.js
@@ -73,10 +73,34 @@ function runMultiElementTest() {
   `.trim());
 }
 
+function runAssetsTest() {
+  const { JSDOM } = jsdom;
+  const dom = new JSDOM(`
+<!DOCTYPE html>
+<html>
+  <body>
+  <img src="/hello.png">
+  <div style="background-image: url(/world.png)">
+  <svg>
+      <image href="../inside-svg.png"></image>
+  </svg>
+  </body>
+</html>
+  `);
+  const { document: doc } = dom.window;
+  const element = doc.querySelector('body');
+  let snapshot = takeDOMSnapshot({ doc, element });
+  assert.equal(snapshot.assetUrls.length, 3);
+  assert.equal(snapshot.assetUrls[0].url, '/hello.png');
+  assert.equal(snapshot.assetUrls[1].url, '/world.png');
+  assert.equal(snapshot.assetUrls[2].url, '../inside-svg.png');
+}
+
 function runTest() {
   runBasicTest();
   runFocusTest();
   runMultiElementTest();
+  runAssetsTest();
 }
 
 runTest();


### PR DESCRIPTION
In SVG elements, you can use <image href=""></image> to include a different image inside the svg. We weren't grabbing asset urls from these elements which led to broken images being displayed in Happo screenshots.