### PR TITLE
Pick stylesheet href from property

### DIFF
--- a/takeDOMSnapshot.js
+++ b/takeDOMSnapshot.js
@@ -13,7 +13,7 @@ function extractCSSBlocks(doc) {
   styleElements.forEach(element => {
     if (element.tagName === 'LINK') {
       // <link href>
-      const href = element.getAttribute('href');
+      const href = element.href || element.getAttribute('href');
       blocks.push({ key: href, href, baseUrl: element.baseURI });
     } else {
       // <style>

--- a/test/takeDOMSnapshot-test.js
+++ b/test/takeDOMSnapshot-test.js
@@ -87,6 +87,9 @@ function runAssetsTest() {
   const dom = new JSDOM(`
 <!DOCTYPE html>
 <html>
+  <head>
+    <link href="/foobar.css" rel="stylesheet" />
+  </head>
   <body>
   <img src="/hello.png">
   <div style="background-image: url(/world.png)">
@@ -103,6 +106,9 @@ function runAssetsTest() {
   assert.equal(snapshot.assetUrls[0].url, '/hello.png');
   assert.equal(snapshot.assetUrls[1].url, '/world.png');
   assert.equal(snapshot.assetUrls[2].url, '../inside-svg.png');
+  assert.equal(snapshot.cssBlocks.length, 1);
+  assert.equal(snapshot.cssBlocks[0].href, '/foobar.css');
+  assert.equal(snapshot.cssBlocks[0].baseUrl, 'about:blank');
 }
 
 function runRadioAndCheckboxTest() {


### PR DESCRIPTION
I noticed that in the browser, calling `element.href` can return the whole URL, including the base URL. For something like

<link href="../foo/bar.css"/>

this can fix certain issues since the baseURL is resolved automatically by the browser. We will get something like

'https://domain.com/foo/bar.css'

back if the page we are on is https://domain.com/hello/ladies.