### PR TITLE
Retry fetch requests, control concurrency in CSS downloads

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -20,14 +20,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
+
       - run: yarn install --frozen-lockfile
       - run: git log --oneline --graph
-      - run: ./run-tests.sh
+
+      - name: Run tests
+        run: ./run-tests.sh
+        env:
+          HAPPO_DEBUG: true
 
   lint:
     runs-on: ubuntu-latest

--- a/controller.js
+++ b/controller.js
@@ -44,27 +44,34 @@ async function downloadCSSContent(blocks) {
       if (HAPPO_DEBUG) {
         console.log(`[HAPPO] Downloading CSS file from ${absUrl}`);
       }
-      const res = await proxiedFetch(absUrl);
-      if (!res.ok) {
+
+      let res;
+      try {
+        res = await proxiedFetch(absUrl, { retryCount: 5 });
+      } catch (e) {
         console.warn(
           `[HAPPO] Failed to fetch CSS file from ${block.href} (using base URL ${block.baseUrl}). This might mean styles are missing in your Happo screenshots`,
         );
         return;
       }
+
       let text = await res.text();
       if (HAPPO_DEBUG) {
         console.log(
           `[HAPPO] Done downloading CSS file from ${absUrl}. Got ${text.length} chars back.`,
         );
       }
+
       if (!absUrl.startsWith(block.baseUrl)) {
         text = makeExternalUrlsAbsolute(text, absUrl);
       }
+
       block.content = text;
       block.assetsBaseUrl = absUrl.replace(/\/[^/]*$/, '/');
       delete block.href;
     }
   });
+
   await Promise.all(promises);
 }
 

--- a/controller.js
+++ b/controller.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 const nodeFetch = require('node-fetch');
 const imageSize = require('image-size');
+const pAll = require('p-all');
 
 const { RemoteBrowserTarget } = require('happo.io');
 const createAssetPackage = require('./src/createAssetPackage');
@@ -38,7 +39,7 @@ function ampersands(string) {
 }
 
 async function downloadCSSContent(blocks) {
-  const promises = blocks.map(async (block) => {
+  const actions = blocks.map((block) => async () => {
     if (block.href) {
       const absUrl = makeAbsolute(block.href, block.baseUrl);
       if (HAPPO_DEBUG) {
@@ -72,7 +73,7 @@ async function downloadCSSContent(blocks) {
     }
   });
 
-  await Promise.all(promises);
+  await pAll(actions, { concurrency: 5 });
 }
 
 class Controller {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "image-size": "^1.0.1",
     "mkdirp": "^1.0.4",
     "node-fetch": "^2.0.0",
+    "p-all": "^3.0.0",
     "parse-srcset": "^1.0.2",
     "string.prototype.replaceall": "^1.0.6",
     "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "archiver": "^7.0.1",
+    "async-retry": "^1.3.3",
     "base64-stream": "^1.0.0",
     "crypto-js": "^4.1.1",
     "https-proxy-agent": "^5.0.0",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,10 @@
 set -euo pipefail
 for file in ./test/*
 do
+  echo ""
+  echo "Running test $file"
+
   node "$file"
+
+  echo "✅ Test $file passed!"
 done

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -112,25 +112,23 @@ module.exports = function createAssetPackage(urls) {
         });
       } else {
         const fetchUrl = makeAbsolute(url, baseUrl);
+
         if (HAPPO_DEBUG) {
           console.log(
             `[HAPPO] Fetching asset from ${fetchUrl} — storing as ${name}`,
           );
         }
+
         try {
-          const fetchRes = await proxiedFetch(fetchUrl);
-          if (!fetchRes.ok) {
-            console.log(
-              `[HAPPO] Failed to fetch url ${fetchUrl} — ${fetchRes.statusText}`,
-            );
-            return;
-          }
+          const fetchRes = await proxiedFetch(fetchUrl, { retryCount: 5 });
+
           if (isDynamic || isExternalUrl) {
             // Add a file suffix so that svg images work
             name = `${name}${getFileSuffixFromMimeType(
               fetchRes.headers.get('content-type'),
             )}`;
           }
+
           // decode URI to make sure "%20" and such are converted to the right
           // chars
           name = decodeURI(name);

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,5 +1,6 @@
 const nodeFetch = require('node-fetch');
 const HttpsProxyAgent = require('https-proxy-agent');
+const asyncRetry = require('async-retry');
 
 const { HTTP_PROXY, HAPPO_DEBUG } = process.env;
 
@@ -11,7 +12,27 @@ if (HAPPO_DEBUG) {
   console.log(`[HAPPO] using the following node-fetch options`, fetchOptions);
 }
 
-module.exports = async function fetch(url) {
-  const fetchRes = await nodeFetch(url, fetchOptions);
-  return fetchRes;
+module.exports = async function fetch(url, { retryCount = 0 }) {
+  return asyncRetry(
+    async () => {
+      const response = await nodeFetch(url, fetchOptions);
+
+      if (!response.ok) {
+        const e = new Error(
+          `[HAPPO] Request to ${url} failed: ${response.status} - ${await response.text()}`,
+        );
+        e.statusCode = response.status;
+        throw e;
+      }
+
+      return response;
+    },
+    {
+      retries: retryCount,
+      onRetry: (e) => {
+        console.warn(`[HAPPO] Failed fetching ${url}. Retrying...`);
+        console.warn(e);
+      },
+    },
+  );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,7 +320,7 @@ assert@^1.4.0:
     object-assign "^4.1.1"
     util "0.10.3"
 
-async-retry@^1.3.1:
+async-retry@^1.3.1, async-retry@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
   integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,6 +234,14 @@ agent-base@6:
   dependencies:
     debug "4"
 
+aggregate-error@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
+  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -617,6 +625,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -1531,6 +1544,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2114,6 +2132,20 @@ os-browserify@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
   integrity sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=
+
+p-all@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-all/-/p-all-3.0.0.tgz#077c023c37e75e760193badab2bad3ccd5782bfb"
+  integrity sha512-qUZbvbBFVXm6uJ7U/WDiO0fv6waBMbjlCm4E66oZdRR+egswICarIdHyVSZZHudH8T5SF8x/JG0q0duFzPnlBw==
+  dependencies:
+    p-map "^4.0.0"
+
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
 
 package-json-from-dist@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
We are seeing some ECONNRESET errors that seem to be happening when we are fetching CSS assets. Currently this causes the job to fail, but I am hoping we can smooth over this by adding some retries. Network flake is inevitable.

This also moves the `res.ok` handling into the fetch function, which allows us to clean up some other code a bit.

This is similar to how we have makeRequest structured in the happo.io package:

https://github.com/happo/happo.io/blob/74b23bf4/src/makeRequest.js

***
Only request 5 CSS files at a time

We are seeing some ECONNERESET errors when downloading a bunch of CSS
files. My current theory is that since we are requesting them all at the
same time, the 6th request is being immediately rejected. I am hoping to
stabilize this by controlling the concurrency here.

