### PR TITLE
Pass link and message through when creating reports

### DIFF
--- a/bin/happo-e2e.js
+++ b/bin/happo-e2e.js
@@ -36,7 +36,7 @@ function parseAllowFailures(argv) {
   return argv.indexOf('--allow-failures') > -1;
 }
 
-async function postAsyncReport({ nonce, afterSha, requestIds }) {
+async function postAsyncReport({ nonce, afterSha, requestIds, link, message }) {
   const happoConfig = await loadHappoConfig();
   if (!happoConfig) {
     return;
@@ -50,6 +50,8 @@ async function postAsyncReport({ nonce, afterSha, requestIds }) {
         requestIds,
         project: happoConfig.project,
         nonce,
+        link,
+        message,
       },
     },
     { ...happoConfig, maxTries: 3 },
@@ -152,6 +154,8 @@ async function finalizeHappoReport() {
     requestIds: [...allRequestIds],
     nonce,
     afterSha,
+    link,
+    message,
   });
   if (beforeSha) {
     const jobResult = await makeRequest(


### PR DESCRIPTION
We noticed that these are on the comparisons but not the reports. Hoping to make the reports a little more useful by passing these through.