### PR TITLE
Fall back to origin/main instead of origin/master

### DIFF
--- a/src/resolveEnvironment.js
+++ b/src/resolveEnvironment.js
@@ -226,7 +226,7 @@ function resolveBeforeSha(env, afterSha) {
   }
 
   const baseBranch =
-    HAPPO_BASE_BRANCH || BASE_BRANCH || baseAzureBranch || 'origin/master';
+    HAPPO_BASE_BRANCH || BASE_BRANCH || baseAzureBranch || 'origin/main';
   const res = spawnSync('git', ['merge-base', baseBranch, afterSha], {
     encoding: 'utf-8',
   });


### PR DESCRIPTION
This has been the default on GitHub for new repos for a while now, and many repos have switched over to using main. I think we should switch in this repo as well.

This is a breaking change.

Addresses HAP-142