### PR TITLE
Ignore test-images and .eslintignore when publishing this package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,9 @@
-node_modules
-test
-run-tests.sh
-.importjs.js
-.github
-.node-version
+.eslintignore
 .eslintrc.js
+.github
+.importjs.js
+.node-version
+node_modules
+run-tests.sh
+test
+test-images


### PR DESCRIPTION
WHen I published v2.6.2 I noticed that the test-images directory was included in the package, which makes the package much larger than it needs to be. Adding it to the ignore list along with an eslint file that also does not need to be distributed.