### PR TITLE
Fix test for main branch rename

### DIFF
--- a/test/resolveEnvironment-test.js
+++ b/test/resolveEnvironment-test.js
@@ -51,7 +51,7 @@ function testAzureEnv() {
     BUILD_REPOSITORY_URI:
       'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',
     SYSTEM_PULLREQUEST_PULLREQUESTID: '99',
-    SYSTEM_PULLREQUEST_TARGETBRANCH: 'refs/head/master',
+    SYSTEM_PULLREQUEST_TARGETBRANCH: 'refs/head/main',
     SYSTEM_PULLREQUEST_SOURCEBRANCH: 'refs/head/dummy-branch',
     SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI:
       'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',


### PR DESCRIPTION
We recently renamed the default branch from master to main, and so we need to adjust our tests a bit.