### PR TITLE
Improve error message when unable to resolve GITHUB_EVENT_PATH

### DIFF
--- a/src/resolveEnvironment.js
+++ b/src/resolveEnvironment.js
@@ -32,6 +32,17 @@ const envKeys = [
   'SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI',
 ];
 
+function resolveGithubEvent(GITHUB_EVENT_PATH) {
+  try {
+    return require(GITHUB_EVENT_PATH);
+  } catch (e) {
+    throw new Error(
+      `Failed to load GitHub event from the GITHUB_EVENT_PATH environment variable: ${JSON.stringify(GITHUB_EVENT_PATH)}`,
+      { cause: e },
+    );
+  }
+}
+
 function resolveLink(env) {
   const {
     CHANGE_URL,
@@ -67,7 +78,8 @@ function resolveLink(env) {
   }
 
   if (GITHUB_EVENT_PATH) {
-    const ghEvent = require(GITHUB_EVENT_PATH);
+    const ghEvent = resolveGithubEvent(GITHUB_EVENT_PATH);
+
     if (ghEvent.pull_request) {
       return ghEvent.pull_request.html_url;
     }
@@ -120,7 +132,7 @@ function resolveMessage(env) {
     return HAPPO_MESSAGE;
   }
   if (GITHUB_EVENT_PATH) {
-    const ghEvent = require(GITHUB_EVENT_PATH);
+    const ghEvent = resolveGithubEvent(GITHUB_EVENT_PATH);
     if (ghEvent.pull_request) {
       return ghEvent.pull_request.title;
     }
@@ -202,7 +214,7 @@ function resolveBeforeSha(env, afterSha) {
   }
 
   if (GITHUB_EVENT_PATH) {
-    const ghEvent = require(GITHUB_EVENT_PATH);
+    const ghEvent = resolveGithubEvent(GITHUB_EVENT_PATH);
     if (ghEvent.pull_request) {
       return ghEvent.pull_request.base.sha;
     }
@@ -273,7 +285,7 @@ function resolveAfterSha(env) {
     return BUILD_SOURCEVERSION;
   }
   if (GITHUB_EVENT_PATH) {
-    const ghEvent = require(GITHUB_EVENT_PATH);
+    const ghEvent = resolveGithubEvent(GITHUB_EVENT_PATH);
     if (ghEvent.pull_request) {
       return ghEvent.pull_request.head.sha;
     }

--- a/test/resolveEnvironment-test.js
+++ b/test/resolveEnvironment-test.js
@@ -147,6 +147,22 @@ function testGithubActionsEnvironment() {
     'https://github.com/octo-org/octo-repo/commit/ccddffddccffdd',
   );
   assert.ok(result.message !== undefined);
+
+  // Try with a non-existing event path
+  let caughtError;
+  try {
+    resolveEnvironment({
+      ...githubEnv,
+      GITHUB_EVENT_PATH: 'non-existing-path',
+    });
+  } catch (e) {
+    caughtError = e;
+  }
+  assert.ok(caughtError);
+  assert.equal(
+    caughtError.message,
+    'Failed to load GitHub event from the GITHUB_EVENT_PATH environment variable: "non-existing-path"',
+  );
 }
 
 function testGithubMergeGroupEnvironment() {


### PR DESCRIPTION
The error message here was a bit cryptic:

```
Error: Cannot find module '/path/to/some/file.json'
Require stack:
- /e2e/node_modules/happo-e2e/src/resolveEnvironment.js
...
```

I want to make it easier for people to troubleshoot this on their own. I think we can try/catch the require and provide a clearer error message that helps people understand that something may be up with the GITHUB_EVENT_PATH environment variable.