### PR TITLE
Always include svgs with <symbol> elements

### DIFF
--- a/playwright-tests/takeDOMSnapshot.test.js
+++ b/playwright-tests/takeDOMSnapshot.test.js
@@ -152,3 +152,21 @@ test('custom element with special stylesheets', async ({ page }) => {
     },
   ]);
 });
+
+test('svg sprites', async ({ page }) => {
+  await setupPage(page);
+
+  await page.goto('/svg-sprites');
+
+  const snapshot = await page.evaluate(() => {
+    return window.happoTakeDOMSnapshot({
+      doc: document,
+      element: document.querySelector('main'),
+    });
+  });
+
+  expect(snapshot.html).toMatch(/<use xlink:href="#my-icon"/s);
+  expect(snapshot.html).toMatch(/<symbol id="my-icon"/s);
+  expect(snapshot.assetUrls).toEqual([]);
+  expect(snapshot.cssBlocks).toEqual([]);
+});

--- a/playwright-tests/test-assets/svg-sprites/index.html
+++ b/playwright-tests/test-assets/svg-sprites/index.html
@@ -1,0 +1,15 @@
+<html>
+  <body>
+    <main>
+      <h1>Hello world</h1>
+      <svg>
+        <use xlink:href="#my-icon" />
+      </svg>
+    </main>
+    <svg>
+      <symbol id="my-icon">
+        <path d="M 10 10 L 10 10" />
+      </symbol>
+    </svg>
+  </body>
+</html>

--- a/takeDOMSnapshot.js
+++ b/takeDOMSnapshot.js
@@ -276,6 +276,12 @@ function inlineShadowRoots(element) {
   }
 }
 
+function findSvgElementsWithSymbols(element) {
+  return [...element.ownerDocument.querySelectorAll('svg')].filter((svg) =>
+    svg.querySelector('symbol'),
+  );
+}
+
 function takeDOMSnapshot({
   doc,
   element: oneOrMoreElements,
@@ -325,6 +331,11 @@ function takeDOMSnapshot({
     );
 
     htmlParts.push(element.outerHTML);
+
+    const svgElementsWithSymbols = findSvgElementsWithSymbols(element);
+    for (const svgElement of svgElementsWithSymbols) {
+      htmlParts.push(`<div style="display: none;">${svgElement.outerHTML}</div>`);
+    }
     if (canvasCleanup) canvasCleanup();
     if (transformCleanup) transformCleanup();
   }


### PR DESCRIPTION
When a page uses `<use>` elements referencing svg snippets defined elsewere on the page, we weren't including the source `<symbol>`s. By always injecting html for all svgs that define the `<symbol>` element, I think we can get these svgs to appear correctly in the screenshots, even when the svgs are defined outside of the element currently beeing screenshot.