### PR TITLE
Add support for `strategy: 'clip'` for takeDOMSnapshot

### DIFF
--- a/playwright-tests/takeDOMSnapshot.test.js
+++ b/playwright-tests/takeDOMSnapshot.test.js
@@ -171,6 +171,44 @@ test('svg sprites', async ({ page }) => {
   expect(snapshot.cssBlocks).toEqual([]);
 });
 
+test('clip strategy', async ({ page }) => {
+  await setupPage(page);
+
+  await page.goto('/svg-sprites');
+
+  const snapshot = await page.evaluate(() => {
+    return window.happoTakeDOMSnapshot({
+      doc: document,
+      element: document.querySelector('main'),
+      strategy: 'clip',
+    });
+  });
+
+  expect(snapshot.html).toMatch(/<use xlink:href="#my-icon"/s);
+  expect((snapshot.html.match(/<symbol id="my-icon"/g) || []).length).toBe(1);
+  expect(snapshot.html).toMatch(/<body/s);
+  expect(snapshot.html).toMatch(/<\/body>/s);
+  expect(snapshot.html).toMatch(/<main data-happo-clip="true">/s);
+  expect(snapshot.assetUrls).toEqual([]);
+  expect(snapshot.cssBlocks).toEqual([]);
+});
+
+test('unknown strategy', async ({ page }) => {
+  await setupPage(page);
+
+  await page.goto('/svg-sprites');
+
+  await expect(
+    page.evaluate(() => {
+      return window.happoTakeDOMSnapshot({
+        doc: document,
+        element: document.querySelector('main'),
+        strategy: 'foobarbaz',
+      });
+    }),
+  ).rejects.toThrow(/Unknown strategy: foobarbaz/);
+});
+
 test('constructed styles', async ({ page }) => {
   await setupPage(page);
 


### PR DESCRIPTION
This option will change the behavior of the DOM snapshot. Instead of only including the element in the resulting html `strategy: 'clip'` will include the entire body, but will leave a data attribute in the DOM for the element under test.

Happo workers will honor this attribute and clip the screenshot on that element.