### PR TITLE
Remove string.prototype.replaceall dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "node-fetch": "^2.0.0",
     "p-all": "^3.0.0",
     "parse-srcset": "^1.0.2",
-    "string.prototype.replaceall": "^1.0.6",
     "yargs": "^17.7.2"
   }
 }

--- a/src/makeExternalUrlsAbsolute.js
+++ b/src/makeExternalUrlsAbsolute.js
@@ -1,10 +1,9 @@
 const { URL } = require('url');
-const replaceAll = require('string.prototype.replaceall');
 
 const findCSSAssetUrls = require('./findCSSAssetUrls');
 
 module.exports = function makeExternalUrlsAbsolute(text, absUrl) {
-  return replaceAll(text, findCSSAssetUrls.URL_PATTERN, (full, pre, url, post) => {
+  return text.replaceAll(findCSSAssetUrls.URL_PATTERN, (full, pre, url, post) => {
     if (url.startsWith('data:')) {
       return full;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,18 +2676,6 @@ string.prototype.matchall@^4.0.0:
     regexp.prototype.flags "^1.3.1"
     side-channel "^1.0.4"
 
-string.prototype.replaceall@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/string.prototype.replaceall/-/string.prototype.replaceall-1.0.6.tgz#566cba7c413713d0b1a85c5dba98b31f8db38196"
-  integrity sha512-OA8VDhE7ssNFlyoDXUHxw6V5cjgPrtosyJKqJX5i1P5tV9eUynsbhx1yz0g+Ye4fjFwAxhKLxt8GSRx2Aqc+Sw==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.19.1"
-    get-intrinsic "^1.1.1"
-    has-symbols "^1.0.2"
-    is-regex "^1.1.4"
-
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"


### PR DESCRIPTION
This has been supported by browsers for a while now, so I think we can remove this dependency without any trouble.