### PR TITLE
Remove mkdirp dependency

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -1,7 +1,6 @@
 const crypto = require('crypto');
 const fs = require('fs');
 
-const { mkdirp } = require('mkdirp');
 const nodeFetch = require('node-fetch');
 const imageSize = require('image-size');
 const pAll = require('p-all');
@@ -537,7 +536,7 @@ Docs:
     const filename = src.slice(1);
     const filenameB64 = `${filename}.b64`;
     if (isFirst) {
-      await mkdirp('.happo-tmp/_inlined');
+      await fs.promises.mkdir('.happo-tmp/_inlined', { recursive: true });
       await new Promise((resolve, reject) =>
         fs.writeFile(filenameB64, base64Chunk, (e) => {
           if (e) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "https-proxy-agent": "^5.0.0",
     "image-size": "^1.0.1",
     "mime-types": "^2.1.35",
-    "mkdirp": "^3.0.1",
     "node-fetch": "^2.0.0",
     "p-all": "^3.0.0",
     "parse-srcset": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1996,11 +1996,6 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
-  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
-
 module-deps@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/module-deps/-/module-deps-6.2.3.tgz#15490bc02af4b56cf62299c7c17cba32d71a96ee"


### PR DESCRIPTION
Node v10 added the recursive option to mkdir, so I think we can safely remove this dependency now.