### PR TITLE
Improve warning message when failing to fetch CSS

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -50,7 +50,7 @@ async function downloadCSSContent(blocks) {
         res = await proxiedFetch(absUrl, { retryCount: 5 });
       } catch (e) {
         console.warn(
-          `[HAPPO] Failed to fetch CSS file from ${block.href} (using base URL ${block.baseUrl}). This might mean styles are missing in your Happo screenshots`,
+          `[HAPPO] Failed to fetch CSS file from ${absUrl} (using ${block.href} with base URL ${block.baseUrl}). This might mean styles are missing in your Happo screenshots.`,
         );
         return;
       }


### PR DESCRIPTION
If the `block.href` here is a full URL, then the `makeAbsolute` function above will not touch it but that's not super clear with how this warning is written. I'm hoping that this makes it easier to understand what's going on here.