### PR TITLE
Use textContent of stylesheet if available

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
   ignorePatterns: ['pages/'],
   parserOptions: {
     sourceType: 'module',
-    ecmaVersion: 2018,
+    ecmaVersion: 2020,
   },
   rules: {
     'no-use-before-define': 2,

--- a/playwright-tests/takeDOMSnapshot.test.js
+++ b/playwright-tests/takeDOMSnapshot.test.js
@@ -49,6 +49,28 @@ test('regular elements', async ({ page }) => {
       baseUrl: 'http://localhost:7700/regular-elements',
     },
   ]);
+
+  expect(snapshot.cssBlocks).toEqual([]);
+});
+
+test('style collection', async ({ page }) => {
+  await setupPage(page);
+
+  await page.goto('/style-collection');
+
+  const snapshot = await page.evaluate(() => {
+    return window.happoTakeDOMSnapshot({ doc: document, element: document.body });
+  });
+
+  expect(snapshot.cssBlocks.length).toBe(2);
+  expect(snapshot.cssBlocks[0].content).toMatch(/font-weight: 400;/);
+  expect(snapshot.cssBlocks[0].content).toMatch(/font: 400 1rem/);
+  expect(snapshot.cssBlocks[0].content).toMatch(/font: var\(--font\)/);
+  expect(snapshot.cssBlocks[0].content).toMatch(
+    /font-weight: var\(--font-weight\);/,
+  );
+
+  expect(snapshot.cssBlocks[1].content).toMatch(/color: yellow;/);
 });
 
 test('one custom element', async ({ page }) => {

--- a/playwright-tests/takeDOMSnapshot.test.js
+++ b/playwright-tests/takeDOMSnapshot.test.js
@@ -63,11 +63,11 @@ test('style collection', async ({ page }) => {
   });
 
   expect(snapshot.cssBlocks.length).toBe(2);
-  expect(snapshot.cssBlocks[0].content).toMatch(/font-weight: 400;/);
-  expect(snapshot.cssBlocks[0].content).toMatch(/font: 400 1rem/);
-  expect(snapshot.cssBlocks[0].content).toMatch(/font: var\(--font\)/);
+  expect(snapshot.cssBlocks[0].content).toMatch(/--my-custom-font: 400 1rem/);
+  expect(snapshot.cssBlocks[0].content).toMatch(/--my-custom-font-weight: 400;/);
+  expect(snapshot.cssBlocks[0].content).toMatch(/font: var\(--my-custom-font\)/);
   expect(snapshot.cssBlocks[0].content).toMatch(
-    /font-weight: var\(--font-weight\);/,
+    /font-weight: var\(--my-custom-font-weight\);/,
   );
 
   expect(snapshot.cssBlocks[1].content).toMatch(/color: yellow;/);
@@ -243,8 +243,12 @@ test('constructed styles', async ({ page }) => {
 
     expect(snapshot.html).toMatch(/<p>world<\/p>/s);
     expect(snapshot.cssBlocks.length).toBe(2);
-    expect(snapshot.cssBlocks[0].content).toEqual('p { color: blue; }');
-    expect(snapshot.cssBlocks[1].content).toEqual('p { color: red; }');
+    expect(snapshot.cssBlocks[0].content.replace(/\s+/g, ' ').trim()).toEqual(
+      'p { color: blue; }',
+    );
+    expect(snapshot.cssBlocks[1].content.replace(/\s+/g, ' ')).toEqual(
+      'p { color: red; }',
+    );
   }
 
   // Take another snapshot to make sure that the styles are not duplicated.
@@ -255,7 +259,11 @@ test('constructed styles', async ({ page }) => {
 
     expect(snapshot.html).toMatch(/<h1>Hello<\/h1>/s);
     expect(snapshot.cssBlocks.length).toBe(2);
-    expect(snapshot.cssBlocks[0].content).toEqual('p { color: blue; }');
-    expect(snapshot.cssBlocks[1].content).toEqual('p { color: red; }');
+    expect(snapshot.cssBlocks[0].content.replace(/\s+/g, ' ').trim()).toEqual(
+      'p { color: blue; }',
+    );
+    expect(snapshot.cssBlocks[1].content.replace(/\s+/g, ' ')).toEqual(
+      'p { color: red; }',
+    );
   }
 });

--- a/playwright-tests/test-assets/style-collection/index.html
+++ b/playwright-tests/test-assets/style-collection/index.html
@@ -2,12 +2,12 @@
   <head>
     <style type="text/css">
       :root {
-        --font: 400 1rem / 1.5rem Roboto, Arial, Helvetica, sans-serif;
-        --font-weight: 400;
+        --my-custom-font: 400 1rem / 1.5rem Roboto, Arial, Helvetica, sans-serif;
+        --my-custom-font-weight: 400;
       }
       p {
-        font: var(--font);
-        font-weight: var(--font-weight);
+        font: var(--my-custom-font);
+        font-weight: var(--my-custom-font-weight);
       }
     </style>
     <style type="text/css" id="dynamic-style"></style>

--- a/playwright-tests/test-assets/style-collection/index.html
+++ b/playwright-tests/test-assets/style-collection/index.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <style type="text/css">
+      :root {
+        --font: 400 1rem / 1.5rem Roboto, Arial, Helvetica, sans-serif;
+        --font-weight: 400;
+      }
+      p {
+        font: var(--font);
+        font-weight: var(--font-weight);
+      }
+    </style>
+    <style type="text/css" id="dynamic-style"></style>
+  </head>
+  <body>
+    <main>Hello world</main>
+  </body>
+  <script src="/style-collection/index.js"></script>
+</html>

--- a/playwright-tests/test-assets/style-collection/index.js
+++ b/playwright-tests/test-assets/style-collection/index.js
@@ -1,0 +1,3 @@
+document.head
+  .querySelector('#dynamic-style')
+  .sheet.insertRule('main { color: yellow; }');


### PR DESCRIPTION
This will fix a bug where our style collection would not work if the stylesheet was using this pattern:

  font: var(--some-var);
  font-weight: var(--some-other-var);

Iterating over cssRules here would mean we collected styles that looked something like:

  font-style: ;
  font-variant-ligatures: ;
  font-variant-caps: ;
  font-variant-numeric: ;
  font-variant-east-asian: ;
  font-variant-alternates: ;
  font-variant-position: ;
  font-variant-emoji: ;
  font-stretch: ;
  font-size: ;
  line-height: ;
  font-family: ;
  font-optical-sizing: ;
  font-size-adjust: ;
  font-kerning: ;
  font-feature-settings: ;
  font-variation-settings: ;
  font-weight: var(--some-other-var);

Notice how properties are expanded and left with no content.

To fix this, we can use `textContent` of the style element instead. And if that isn't available, we fall back to `sheet.cssRules`.

The only potential issue this could introduce is if you mix text content styles and dynamically injected ones (using e.g. `insertRule`). I doubt that's a common way to create styling however.