### PR TITLE
Revert "Remove describe from tests"

### DIFF
--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -1,4 +1,4 @@
-const { it, before, after } = require('node:test');
+const { describe, it, before, after } = require('node:test');
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
@@ -30,13 +30,15 @@ after(() => {
   fs.unlinkSync(mockHappoConfigPath);
 });
 
-it('initializes with the correct happo config', async () => {
-  const controller = new Controller();
-  await controller.init();
-  assert.strictEqual(controller.happoConfig.apiKey, mockHappoConfig.apiKey);
-  assert.strictEqual(controller.happoConfig.apiSecret, mockHappoConfig.apiSecret);
-  assert.strictEqual(controller.happoConfig.project, mockHappoConfig.project);
-  assert.deepStrictEqual(controller.snapshots, []);
-  assert.deepStrictEqual(controller.snapshotAssetUrls, []);
-  assert.deepStrictEqual(controller.allCssBlocks, []);
+describe('Controller', () => {
+  it('initializes with the correct happo config', async () => {
+    const controller = new Controller();
+    await controller.init();
+    assert.strictEqual(controller.happoConfig.apiKey, mockHappoConfig.apiKey);
+    assert.strictEqual(controller.happoConfig.apiSecret, mockHappoConfig.apiSecret);
+    assert.strictEqual(controller.happoConfig.project, mockHappoConfig.project);
+    assert.deepStrictEqual(controller.snapshots, []);
+    assert.deepStrictEqual(controller.snapshotAssetUrls, []);
+    assert.deepStrictEqual(controller.allCssBlocks, []);
+  });
 });

--- a/test/createAssetPackage-test.js
+++ b/test/createAssetPackage-test.js
@@ -1,4 +1,4 @@
-const { it } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('assert');
 const fs = require('fs');
 
@@ -33,23 +33,25 @@ async function wrap(func) {
   }
 }
 
-it('creates an asset package', async () => {
-  await wrap(async () => {
-    const pkg = await createAssetPackage([
-      {
-        url: '/sub%20folder/countries-bg.jpeg',
-        baseUrl: 'http://localhost:3412',
-      },
-      {
-        url: 'http://localhost:3412/sub%20folder/countries-bg.jpeg',
-        baseUrl: 'http://localhost:3412',
-      },
-      {
-        url: 'http://localhost:3412/foo.html',
-        baseUrl: 'http://localhost:3412',
-      },
-    ]);
-    assert.equal(pkg.hash, '898862aad00d429b73f57256332a6ee1');
-    return pkg;
+describe('createAssetPackage', () => {
+  it('creates an asset package', async () => {
+    await wrap(async () => {
+      const pkg = await createAssetPackage([
+        {
+          url: '/sub%20folder/countries-bg.jpeg',
+          baseUrl: 'http://localhost:3412',
+        },
+        {
+          url: 'http://localhost:3412/sub%20folder/countries-bg.jpeg',
+          baseUrl: 'http://localhost:3412',
+        },
+        {
+          url: 'http://localhost:3412/foo.html',
+          baseUrl: 'http://localhost:3412',
+        },
+      ]);
+      assert.equal(pkg.hash, '898862aad00d429b73f57256332a6ee1');
+      return pkg;
+    });
   });
 });

--- a/test/findCSSAssetUrls-test.js
+++ b/test/findCSSAssetUrls-test.js
@@ -1,12 +1,13 @@
-const { it } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('assert');
 
 const findCSSAssetUrls = require('../src/findCSSAssetUrls');
 
-it('finds asset urls in CSS', () => {
-  assert.deepEqual(
-    findCSSAssetUrls(
-      `
+describe('findCSSAssetUrls', () => {
+  it('finds asset urls in CSS', () => {
+    assert.deepEqual(
+      findCSSAssetUrls(
+        `
         .foo {
           background-image: url("/bar.png");
         }
@@ -19,7 +20,8 @@ it('finds asset urls in CSS', () => {
           background: url(data:image/png;base64,asdfasdfasfd);
         }
       `.trim(),
-    ),
-    ['/bar.png', '/fonts/myfont.woff2', '/fonts/myfont.woff'],
-  );
+      ),
+      ['/bar.png', '/fonts/myfont.woff2', '/fonts/myfont.woff'],
+    );
+  });
 });

--- a/test/makeAbsolute-test.js
+++ b/test/makeAbsolute-test.js
@@ -1,57 +1,65 @@
-const { it } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('node:assert');
 
 const makeAbsolute = require('../src/makeAbsolute');
 
 const baseUrl = 'https://base.url';
 
-it('prepends baseUrl if protocol is missing', () => {
-  assert.equal(makeAbsolute('/foo.png', baseUrl), 'https://base.url/foo.png');
-  assert.equal(
-    makeAbsolute('/bar/foo.png', baseUrl),
-    'https://base.url/bar/foo.png',
-  );
-  assert.equal(makeAbsolute('bar/foo.png', baseUrl), 'https://base.url/bar/foo.png');
-  assert.equal(
-    makeAbsolute('../bar/foo.png', 'http://goo.bar/foo/'),
-    'http://goo.bar/bar/foo.png',
-  );
-  assert.equal(
-    makeAbsolute('../bar/foo.png', 'http://goo.bar/foo/test.html?foo=bar'),
-    'http://goo.bar/bar/foo.png',
-  );
-  assert.equal(
-    makeAbsolute('./bar/foo.png', 'http://goo.bar/foo/test.html?foo=bar#difference'),
-    'http://goo.bar/foo/bar/foo.png',
-  );
-  assert.equal(
-    makeAbsolute('/bar/foo.png', 'http://goo.bar/foo/'),
-    'http://goo.bar/bar/foo.png',
-  );
-  assert.equal(
-    makeAbsolute('./foo.png', 'http://goo.bar'),
-    'http://goo.bar/foo.png',
-  );
-  assert.equal(
-    makeAbsolute('foo/bar/baz.png', 'http://goo.bar/car/'),
-    'http://goo.bar/car/foo/bar/baz.png',
-  );
-});
+describe('makeAbsolute', () => {
+  it('prepends baseUrl if protocol is missing', () => {
+    assert.equal(makeAbsolute('/foo.png', baseUrl), 'https://base.url/foo.png');
+    assert.equal(
+      makeAbsolute('/bar/foo.png', baseUrl),
+      'https://base.url/bar/foo.png',
+    );
+    assert.equal(
+      makeAbsolute('bar/foo.png', baseUrl),
+      'https://base.url/bar/foo.png',
+    );
+    assert.equal(
+      makeAbsolute('../bar/foo.png', 'http://goo.bar/foo/'),
+      'http://goo.bar/bar/foo.png',
+    );
+    assert.equal(
+      makeAbsolute('../bar/foo.png', 'http://goo.bar/foo/test.html?foo=bar'),
+      'http://goo.bar/bar/foo.png',
+    );
+    assert.equal(
+      makeAbsolute(
+        './bar/foo.png',
+        'http://goo.bar/foo/test.html?foo=bar#difference',
+      ),
+      'http://goo.bar/foo/bar/foo.png',
+    );
+    assert.equal(
+      makeAbsolute('/bar/foo.png', 'http://goo.bar/foo/'),
+      'http://goo.bar/bar/foo.png',
+    );
+    assert.equal(
+      makeAbsolute('./foo.png', 'http://goo.bar'),
+      'http://goo.bar/foo.png',
+    );
+    assert.equal(
+      makeAbsolute('foo/bar/baz.png', 'http://goo.bar/car/'),
+      'http://goo.bar/car/foo/bar/baz.png',
+    );
+  });
 
-it('returns absolute URL if protocol is present', () => {
-  assert.equal(
-    makeAbsolute('http://elsewhere.com/bar.png', baseUrl),
-    'http://elsewhere.com/bar.png',
-  );
-  assert.equal(
-    makeAbsolute('https://elsewhere.com/bar.png', baseUrl),
-    'https://elsewhere.com/bar.png',
-  );
-});
+  it('returns absolute URL if protocol is present', () => {
+    assert.equal(
+      makeAbsolute('http://elsewhere.com/bar.png', baseUrl),
+      'http://elsewhere.com/bar.png',
+    );
+    assert.equal(
+      makeAbsolute('https://elsewhere.com/bar.png', baseUrl),
+      'https://elsewhere.com/bar.png',
+    );
+  });
 
-it('handles relative protocol URLs', () => {
-  assert.equal(
-    makeAbsolute('//elsewhere.com/bar.png', baseUrl),
-    'https://elsewhere.com/bar.png',
-  );
+  it('handles relative protocol URLs', () => {
+    assert.equal(
+      makeAbsolute('//elsewhere.com/bar.png', baseUrl),
+      'https://elsewhere.com/bar.png',
+    );
+  });
 });

--- a/test/makeExternalUrlsAbsolute-test.js
+++ b/test/makeExternalUrlsAbsolute-test.js
@@ -1,14 +1,15 @@
-const { it } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('assert');
 
 const makeExternalUrlsAbsolute = require('../src/makeExternalUrlsAbsolute');
 
 const resourceUrl = 'https://base.url/styles/styles.min.css';
 
-it('updates urls', () => {
-  assert.equal(
-    makeExternalUrlsAbsolute(
-      `
+describe('makeExternalUrlsAbsolute', () => {
+  it('updates urls', () => {
+    assert.equal(
+      makeExternalUrlsAbsolute(
+        `
           .foo {
             background-image: url("/bar.png");
           }
@@ -25,9 +26,9 @@ it('updates urls', () => {
             background-image: url(two.png);
           }
         `.trim(),
-      resourceUrl,
-    ),
-    `
+        resourceUrl,
+      ),
+      `
           .foo {
             background-image: url("https://base.url/bar.png");
           }
@@ -44,9 +45,10 @@ it('updates urls', () => {
             background-image: url(https://base.url/styles/two.png);
           }
         `.trim(),
-  );
-});
+    );
+  });
 
-it('can deal with empty input', () => {
-  assert.equal(makeExternalUrlsAbsolute('', resourceUrl), '');
+  it('can deal with empty input', () => {
+    assert.equal(makeExternalUrlsAbsolute('', resourceUrl), '');
+  });
 });

--- a/test/resolveEnvironment-test.js
+++ b/test/resolveEnvironment-test.js
@@ -1,204 +1,205 @@
-const { it } = require('node:test');
+const { describe, it } = require('node:test');
 const path = require('path');
 const assert = require('assert');
 const resolveEnvironment = require('../src/resolveEnvironment');
 
-it('resolves the dev environment', () => {
-  const result = resolveEnvironment({});
-  assert.equal(result.beforeSha, '__LATEST__');
-  assert.ok(/^dev-[a-z0-9]+$/.test(result.afterSha));
-  assert.equal(result.link, undefined);
-  assert.equal(result.message, undefined);
-});
-
-it('resolves the CircleCI environment', () => {
-  const circleEnv = {
-    CI_PULL_REQUEST: 'https://ghe.com/foo/bar/pull/12',
-    CIRCLE_PROJECT_USERNAME: 'happo',
-    CIRCLE_PROJECT_REPONAME: 'happo-view',
-    CIRCLE_SHA1: 'abcdef',
-  };
-  let result = resolveEnvironment(circleEnv);
-  assert.equal(result.beforeSha, undefined);
-  assert.equal(result.afterSha, 'abcdef');
-  assert.equal(result.link, 'https://ghe.com/foo/bar/pull/12');
-  assert.ok(result.message !== undefined);
-
-  // Try with a real commit sha in the repo
-  result = resolveEnvironment({
-    ...circleEnv,
-    CIRCLE_SHA1: '4521c1411c5c0ad19fd72fa31b12363ab54d5eab',
+describe('resolveEnvironment', () => {
+  it('resolves the dev environment', () => {
+    const result = resolveEnvironment({});
+    assert.equal(result.beforeSha, '__LATEST__');
+    assert.ok(/^dev-[a-z0-9]+$/.test(result.afterSha));
+    assert.equal(result.link, undefined);
+    assert.equal(result.message, undefined);
   });
 
-  assert.equal(result.afterSha, '4521c1411c5c0ad19fd72fa31b12363ab54d5eab');
-  assert.equal(result.link, 'https://ghe.com/foo/bar/pull/12');
-  assert.ok(result.message !== undefined);
+  it('resolves the CircleCI environment', () => {
+    const circleEnv = {
+      CI_PULL_REQUEST: 'https://ghe.com/foo/bar/pull/12',
+      CIRCLE_PROJECT_USERNAME: 'happo',
+      CIRCLE_PROJECT_REPONAME: 'happo-view',
+      CIRCLE_SHA1: 'abcdef',
+    };
+    let result = resolveEnvironment(circleEnv);
+    assert.equal(result.beforeSha, undefined);
+    assert.equal(result.afterSha, 'abcdef');
+    assert.equal(result.link, 'https://ghe.com/foo/bar/pull/12');
+    assert.ok(result.message !== undefined);
 
-  // Try with a non-pr env
-  result = resolveEnvironment({
-    ...circleEnv,
-    CI_PULL_REQUEST: undefined,
-  });
-
-  assert.equal(result.beforeSha, undefined);
-  assert.equal(result.afterSha, 'abcdef');
-  assert.equal(result.link, 'https://github.com/happo/happo-view/commit/abcdef');
-  assert.ok(result.message !== undefined);
-});
-
-it('resolves the Azure environment', () => {
-  const azureEnv = {
-    BUILD_SOURCEVERSION: '25826448f15ebcb939804ca769a00ee1df08e10d',
-    BUILD_REPOSITORY_URI:
-      'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',
-    SYSTEM_PULLREQUEST_PULLREQUESTID: '99',
-    SYSTEM_PULLREQUEST_TARGETBRANCH: 'refs/head/main',
-    SYSTEM_PULLREQUEST_SOURCEBRANCH: 'refs/head/dummy-branch',
-    SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI:
-      'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',
-  };
-  let result = resolveEnvironment(azureEnv);
-  assert.equal(result.afterSha, '56abe22357deecf8be0c54325793789c5907b83f');
-  assert.equal(result.beforeSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
-  assert.equal(
-    result.link,
-    'https://dev.azure.com/trotzig/_git/happo-demo-azure-full-page/pullrequest/99',
-  );
-  assert.ok(result.message !== undefined);
-
-  // Try with a non-pr env
-  result = resolveEnvironment({
-    ...azureEnv,
-    SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: undefined,
-    SYSTEM_PULLREQUEST_SOURCEBRANCH: undefined,
-    SYSTEM_PULLREQUEST_TARGETBRANCH: undefined,
-    SYSTEM_PULLREQUEST_PULLREQUESTID: undefined,
-  });
-
-  assert.equal(result.afterSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
-  assert.equal(result.beforeSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
-  assert.equal(
-    result.link,
-    'https://dev.azure.com/trotzig/_git/happo-demo-azure-full-page/commit/25826448f15ebcb939804ca769a00ee1df08e10d',
-  );
-  assert.ok(result.message !== undefined);
-
-  // assert.equal(result.beforeSha, undefined);
-  // assert.equal(result.afterSha, 'abcdef');
-  // assert.equal(
-  //   result.link,
-  //   'https://github.com/happo/happo-view/commit/abcdef',
-  // );
-  // assert.ok(result.message !== undefined);
-});
-
-it('resolves the tag matching environment', () => {
-  const azureEnv = {
-    BUILD_SOURCEVERSION: '25826448f15ebcb939804ca769a00ee1df08e10d',
-    BUILD_REPOSITORY_URI:
-      'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',
-    HAPPO_BEFORE_SHA_TAG_MATCHER: 'happo-*',
-  };
-  let result = resolveEnvironment(azureEnv);
-  assert.equal(result.afterSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
-  assert.equal(result.beforeSha, 'dff9416bd579847b94c72682fa1a611f372d23e4');
-
-  // Try with a matcher that doesn't match anything
-  result = resolveEnvironment({
-    ...azureEnv,
-    HAPPO_BEFORE_SHA_TAG_MATCHER: 'happo-dobedoo-*',
-  });
-
-  assert.equal(result.afterSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
-  assert.equal(result.beforeSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
-});
-
-it('resolves the GitHub Actions environment', () => {
-  const githubEnv = {
-    GITHUB_SHA: 'ccddffddccffdd',
-    GITHUB_EVENT_PATH: path.resolve(__dirname, 'github_pull_request_event.json'),
-  };
-  let result = resolveEnvironment(githubEnv);
-  assert.equal(result.beforeSha, 'f95f852bd8fca8fcc58a9a2d6c842781e32a215e');
-  assert.equal(result.afterSha, 'ec26c3e57ca3a959ca5aad62de7213c562f8c821');
-  assert.equal(result.link, 'https://github.com/Codertocat/Hello-World/pull/2');
-  assert.equal(result.message, 'Update the README with new information.');
-
-  // Try with a push event
-  githubEnv.GITHUB_EVENT_PATH = path.resolve(__dirname, 'github_push_event.json');
-  result = resolveEnvironment(githubEnv);
-  assert.equal(result.beforeSha, '6113728f27ae82c7b1a177c8d03f9e96e0adf246');
-  assert.equal(result.afterSha, '0000000000000000000000000000000000000000');
-  assert.equal(
-    result.link,
-    'https://github.com/foo/bar/commit/0000000000000000000000000000000000000000',
-  );
-  assert.ok(result.message !== undefined);
-
-  // Try with a workflow_dispatch event
-  githubEnv.GITHUB_EVENT_PATH = path.resolve(
-    __dirname,
-    'github_workflow_dispatch.json',
-  );
-  result = resolveEnvironment(githubEnv);
-  assert.equal(result.beforeSha, undefined);
-  assert.equal(result.afterSha, 'ccddffddccffdd');
-  assert.equal(
-    result.link,
-    'https://github.com/octo-org/octo-repo/commit/ccddffddccffdd',
-  );
-  assert.ok(result.message !== undefined);
-
-  // Try with a non-existing event path
-  let caughtError;
-  try {
-    resolveEnvironment({
-      ...githubEnv,
-      GITHUB_EVENT_PATH: 'non-existing-path',
+    // Try with a real commit sha in the repo
+    result = resolveEnvironment({
+      ...circleEnv,
+      CIRCLE_SHA1: '4521c1411c5c0ad19fd72fa31b12363ab54d5eab',
     });
-  } catch (e) {
-    caughtError = e;
-  }
-  assert.ok(caughtError);
-  assert.equal(
-    caughtError.message,
-    'Failed to load GitHub event from the GITHUB_EVENT_PATH environment variable: "non-existing-path"',
-  );
-});
 
-it('resolves the GitHub merge group environment', () => {
-  const githubEnv = {
-    GITHUB_SHA: 'ccddffddccffdd',
-    GITHUB_EVENT_PATH: path.resolve(__dirname, 'github_merge_group_event.json'),
-  };
-  let result = resolveEnvironment(githubEnv);
-  assert.equal(result.beforeSha, 'f95f852bd8fca8fcc58a9a2d6c842781e32a215e');
-  assert.equal(result.afterSha, 'ec26c3e57ca3a959ca5aad62de7213c562f8c821');
-  assert.equal(
-    result.link,
-    'https://github.com/Codertocat/Hello-World/commit/ec26c3e57ca3a959ca5aad62de7213c562f8c821',
-  );
-  assert.ok(result.message !== undefined);
-});
+    assert.equal(result.afterSha, '4521c1411c5c0ad19fd72fa31b12363ab54d5eab');
+    assert.equal(result.link, 'https://ghe.com/foo/bar/pull/12');
+    assert.ok(result.message !== undefined);
 
-it('resolves the Travis environment', () => {
-  const travisEnv = {
-    HAPPO_GITHUB_BASE: 'http://git.hub',
-    TRAVIS_REPO_SLUG: 'owner/repo',
-    TRAVIS_PULL_REQUEST: 12,
-    TRAVIS_PULL_REQUEST_SHA: 'abcdef',
-    TRAVIS_COMMIT_RANGE: 'ttvvb...abcdef',
-    TRAVIS_COMMIT: 'xyz',
-  };
+    // Try with a non-pr env
+    result = resolveEnvironment({
+      ...circleEnv,
+      CI_PULL_REQUEST: undefined,
+    });
 
-  let result = resolveEnvironment(travisEnv);
-  assert.equal(result.beforeSha, 'ttvvb');
-  assert.equal(result.afterSha, 'abcdef');
-  assert.equal(result.link, 'http://git.hub/owner/repo/pull/12');
-  assert.ok(result.message !== undefined);
+    assert.equal(result.beforeSha, undefined);
+    assert.equal(result.afterSha, 'abcdef');
+    assert.equal(result.link, 'https://github.com/happo/happo-view/commit/abcdef');
+    assert.ok(result.message !== undefined);
+  });
 
-  // Try with a real commit sha in the repo
-  /*
+  it('resolves the Azure environment', () => {
+    const azureEnv = {
+      BUILD_SOURCEVERSION: '25826448f15ebcb939804ca769a00ee1df08e10d',
+      BUILD_REPOSITORY_URI:
+        'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',
+      SYSTEM_PULLREQUEST_PULLREQUESTID: '99',
+      SYSTEM_PULLREQUEST_TARGETBRANCH: 'refs/head/main',
+      SYSTEM_PULLREQUEST_SOURCEBRANCH: 'refs/head/dummy-branch',
+      SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI:
+        'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',
+    };
+    let result = resolveEnvironment(azureEnv);
+    assert.equal(result.afterSha, '56abe22357deecf8be0c54325793789c5907b83f');
+    assert.equal(result.beforeSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
+    assert.equal(
+      result.link,
+      'https://dev.azure.com/trotzig/_git/happo-demo-azure-full-page/pullrequest/99',
+    );
+    assert.ok(result.message !== undefined);
+
+    // Try with a non-pr env
+    result = resolveEnvironment({
+      ...azureEnv,
+      SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI: undefined,
+      SYSTEM_PULLREQUEST_SOURCEBRANCH: undefined,
+      SYSTEM_PULLREQUEST_TARGETBRANCH: undefined,
+      SYSTEM_PULLREQUEST_PULLREQUESTID: undefined,
+    });
+
+    assert.equal(result.afterSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
+    assert.equal(result.beforeSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
+    assert.equal(
+      result.link,
+      'https://dev.azure.com/trotzig/_git/happo-demo-azure-full-page/commit/25826448f15ebcb939804ca769a00ee1df08e10d',
+    );
+    assert.ok(result.message !== undefined);
+
+    // assert.equal(result.beforeSha, undefined);
+    // assert.equal(result.afterSha, 'abcdef');
+    // assert.equal(
+    //   result.link,
+    //   'https://github.com/happo/happo-view/commit/abcdef',
+    // );
+    // assert.ok(result.message !== undefined);
+  });
+
+  it('resolves the tag matching environment', () => {
+    const azureEnv = {
+      BUILD_SOURCEVERSION: '25826448f15ebcb939804ca769a00ee1df08e10d',
+      BUILD_REPOSITORY_URI:
+        'https://trotzig@dev.azure.com/trotzig/_git/happo-demo-azure-full-page',
+      HAPPO_BEFORE_SHA_TAG_MATCHER: 'happo-*',
+    };
+    let result = resolveEnvironment(azureEnv);
+    assert.equal(result.afterSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
+    assert.equal(result.beforeSha, 'dff9416bd579847b94c72682fa1a611f372d23e4');
+
+    // Try with a matcher that doesn't match anything
+    result = resolveEnvironment({
+      ...azureEnv,
+      HAPPO_BEFORE_SHA_TAG_MATCHER: 'happo-dobedoo-*',
+    });
+
+    assert.equal(result.afterSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
+    assert.equal(result.beforeSha, '25826448f15ebcb939804ca769a00ee1df08e10d');
+  });
+
+  it('resolves the GitHub Actions environment', () => {
+    const githubEnv = {
+      GITHUB_SHA: 'ccddffddccffdd',
+      GITHUB_EVENT_PATH: path.resolve(__dirname, 'github_pull_request_event.json'),
+    };
+    let result = resolveEnvironment(githubEnv);
+    assert.equal(result.beforeSha, 'f95f852bd8fca8fcc58a9a2d6c842781e32a215e');
+    assert.equal(result.afterSha, 'ec26c3e57ca3a959ca5aad62de7213c562f8c821');
+    assert.equal(result.link, 'https://github.com/Codertocat/Hello-World/pull/2');
+    assert.equal(result.message, 'Update the README with new information.');
+
+    // Try with a push event
+    githubEnv.GITHUB_EVENT_PATH = path.resolve(__dirname, 'github_push_event.json');
+    result = resolveEnvironment(githubEnv);
+    assert.equal(result.beforeSha, '6113728f27ae82c7b1a177c8d03f9e96e0adf246');
+    assert.equal(result.afterSha, '0000000000000000000000000000000000000000');
+    assert.equal(
+      result.link,
+      'https://github.com/foo/bar/commit/0000000000000000000000000000000000000000',
+    );
+    assert.ok(result.message !== undefined);
+
+    // Try with a workflow_dispatch event
+    githubEnv.GITHUB_EVENT_PATH = path.resolve(
+      __dirname,
+      'github_workflow_dispatch.json',
+    );
+    result = resolveEnvironment(githubEnv);
+    assert.equal(result.beforeSha, undefined);
+    assert.equal(result.afterSha, 'ccddffddccffdd');
+    assert.equal(
+      result.link,
+      'https://github.com/octo-org/octo-repo/commit/ccddffddccffdd',
+    );
+    assert.ok(result.message !== undefined);
+
+    // Try with a non-existing event path
+    let caughtError;
+    try {
+      resolveEnvironment({
+        ...githubEnv,
+        GITHUB_EVENT_PATH: 'non-existing-path',
+      });
+    } catch (e) {
+      caughtError = e;
+    }
+    assert.ok(caughtError);
+    assert.equal(
+      caughtError.message,
+      'Failed to load GitHub event from the GITHUB_EVENT_PATH environment variable: "non-existing-path"',
+    );
+  });
+
+  it('resolves the GitHub merge group environment', () => {
+    const githubEnv = {
+      GITHUB_SHA: 'ccddffddccffdd',
+      GITHUB_EVENT_PATH: path.resolve(__dirname, 'github_merge_group_event.json'),
+    };
+    let result = resolveEnvironment(githubEnv);
+    assert.equal(result.beforeSha, 'f95f852bd8fca8fcc58a9a2d6c842781e32a215e');
+    assert.equal(result.afterSha, 'ec26c3e57ca3a959ca5aad62de7213c562f8c821');
+    assert.equal(
+      result.link,
+      'https://github.com/Codertocat/Hello-World/commit/ec26c3e57ca3a959ca5aad62de7213c562f8c821',
+    );
+    assert.ok(result.message !== undefined);
+  });
+
+  it('resolves the Travis environment', () => {
+    const travisEnv = {
+      HAPPO_GITHUB_BASE: 'http://git.hub',
+      TRAVIS_REPO_SLUG: 'owner/repo',
+      TRAVIS_PULL_REQUEST: 12,
+      TRAVIS_PULL_REQUEST_SHA: 'abcdef',
+      TRAVIS_COMMIT_RANGE: 'ttvvb...abcdef',
+      TRAVIS_COMMIT: 'xyz',
+    };
+
+    let result = resolveEnvironment(travisEnv);
+    assert.equal(result.beforeSha, 'ttvvb');
+    assert.equal(result.afterSha, 'abcdef');
+    assert.equal(result.link, 'http://git.hub/owner/repo/pull/12');
+    assert.ok(result.message !== undefined);
+
+    // Try with a real commit sha in the repo
+    /*
    * Disabled until the new happo-e2e repo has enough commits
    *
   result = resolveEnvironment({
@@ -227,45 +228,46 @@ bdac2595db20ad2a6bf335b59510aa771125526a
   );
   assert.ok(result.message !== undefined);
   */
-});
-
-it('resolves the happo environment', () => {
-  const happoEnv = {
-    HAPPO_CURRENT_SHA: 'bdac2595db20ad2a6bf335b59510aa771125526a',
-    HAPPO_PREVIOUS_SHA: 'hhhggg',
-    HAPPO_CHANGE_URL: 'link://link',
-    HAPPO_NOTIFY: 'foo@bar.com,bar@foo.com',
-  };
-
-  let result = resolveEnvironment(happoEnv);
-  assert.equal(result.beforeSha, 'hhhggg');
-  assert.equal(result.afterSha, 'bdac2595db20ad2a6bf335b59510aa771125526a');
-  assert.equal(result.link, 'link://link');
-  assert.equal(result.notify, 'foo@bar.com,bar@foo.com');
-  assert.ok(result.message !== undefined);
-
-  // Try with legacy overrides
-  result = resolveEnvironment({
-    CURRENT_SHA: 'foobar',
-    PREVIOUS_SHA: 'barfo',
-    CHANGE_URL: 'url://link',
-    HAPPO_MESSAGE: 'This is a change',
   });
 
-  assert.equal(result.beforeSha, 'barfo');
-  assert.equal(result.afterSha, 'foobar');
-  assert.equal(result.link, 'url://link');
-  assert.equal(result.message, 'This is a change');
+  it('resolves the happo environment', () => {
+    const happoEnv = {
+      HAPPO_CURRENT_SHA: 'bdac2595db20ad2a6bf335b59510aa771125526a',
+      HAPPO_PREVIOUS_SHA: 'hhhggg',
+      HAPPO_CHANGE_URL: 'link://link',
+      HAPPO_NOTIFY: 'foo@bar.com,bar@foo.com',
+    };
 
-  // Try overriding base branch
-  result = resolveEnvironment({
-    ...happoEnv,
-    HAPPO_BASE_BRANCH: 'non-existing',
-    HAPPO_PREVIOUS_SHA: undefined,
+    let result = resolveEnvironment(happoEnv);
+    assert.equal(result.beforeSha, 'hhhggg');
+    assert.equal(result.afterSha, 'bdac2595db20ad2a6bf335b59510aa771125526a');
+    assert.equal(result.link, 'link://link');
+    assert.equal(result.notify, 'foo@bar.com,bar@foo.com');
+    assert.ok(result.message !== undefined);
+
+    // Try with legacy overrides
+    result = resolveEnvironment({
+      CURRENT_SHA: 'foobar',
+      PREVIOUS_SHA: 'barfo',
+      CHANGE_URL: 'url://link',
+      HAPPO_MESSAGE: 'This is a change',
+    });
+
+    assert.equal(result.beforeSha, 'barfo');
+    assert.equal(result.afterSha, 'foobar');
+    assert.equal(result.link, 'url://link');
+    assert.equal(result.message, 'This is a change');
+
+    // Try overriding base branch
+    result = resolveEnvironment({
+      ...happoEnv,
+      HAPPO_BASE_BRANCH: 'non-existing',
+      HAPPO_PREVIOUS_SHA: undefined,
+    });
+
+    assert.ok(result.beforeSha === undefined);
+    assert.equal(result.afterSha, 'bdac2595db20ad2a6bf335b59510aa771125526a');
+    assert.equal(result.link, 'link://link');
+    assert.ok(result.message !== undefined);
   });
-
-  assert.ok(result.beforeSha === undefined);
-  assert.equal(result.afterSha, 'bdac2595db20ad2a6bf335b59510aa771125526a');
-  assert.equal(result.link, 'link://link');
-  assert.ok(result.message !== undefined);
 });

--- a/test/takeDOMSnapshot-test.js
+++ b/test/takeDOMSnapshot-test.js
@@ -1,12 +1,13 @@
-const { it } = require('node:test');
+const { describe, it } = require('node:test');
 const assert = require('assert');
 const jsdom = require('jsdom');
 
 const takeDOMSnapshot = require('../takeDOMSnapshot');
 
-it('takes a basic snapshot', () => {
-  const { JSDOM } = jsdom;
-  const dom = new JSDOM(`
+describe('takeDOMSnapshot', () => {
+  it('takes a basic snapshot', () => {
+    const { JSDOM } = jsdom;
+    const dom = new JSDOM(`
 <!DOCTYPE html>
 <html class="page">
   <body data-something="foo">
@@ -14,17 +15,17 @@ it('takes a basic snapshot', () => {
   </body>
 </html>
   `);
-  const { document: doc } = dom.window;
-  const element = doc.querySelector('main');
-  const snapshot = takeDOMSnapshot({ doc, element });
-  assert.equal(snapshot.html, '<main>Hello world</main>');
-  assert.deepEqual(snapshot.htmlElementAttrs, { class: 'page' });
-  assert.deepEqual(snapshot.bodyElementAttrs, { 'data-something': 'foo' });
-});
+    const { document: doc } = dom.window;
+    const element = doc.querySelector('main');
+    const snapshot = takeDOMSnapshot({ doc, element });
+    assert.equal(snapshot.html, '<main>Hello world</main>');
+    assert.deepEqual(snapshot.htmlElementAttrs, { class: 'page' });
+    assert.deepEqual(snapshot.bodyElementAttrs, { 'data-something': 'foo' });
+  });
 
-it('works with data-happo-focus', () => {
-  const { JSDOM } = jsdom;
-  const dom = new JSDOM(`
+  it('works with data-happo-focus', () => {
+    const { JSDOM } = jsdom;
+    const dom = new JSDOM(`
 <!DOCTYPE html>
 <html>
   <body>
@@ -35,35 +36,35 @@ it('works with data-happo-focus', () => {
   </body>
 </html>
   `);
-  const { document: doc } = dom.window;
-  const element = doc.querySelector('main');
-  let snapshot = takeDOMSnapshot({ doc, element });
-  assert.equal(
-    snapshot.html.trim(),
-    `
+    const { document: doc } = dom.window;
+    const element = doc.querySelector('main');
+    let snapshot = takeDOMSnapshot({ doc, element });
+    assert.equal(
+      snapshot.html.trim(),
+      `
     <main>
       <input type="text" name="name">
       <input type="checkbox">
     </main>
   `.trim(),
-  );
+    );
 
-  element.querySelector('input').focus();
-  snapshot = takeDOMSnapshot({ doc, element });
-  assert.equal(
-    snapshot.html.trim(),
-    `
+    element.querySelector('input').focus();
+    snapshot = takeDOMSnapshot({ doc, element });
+    assert.equal(
+      snapshot.html.trim(),
+      `
     <main>
       <input type="text" name="name" data-happo-focus="true">
       <input type="checkbox">
     </main>
   `.trim(),
-  );
-});
+    );
+  });
 
-it('works with multiple elements', () => {
-  const { JSDOM } = jsdom;
-  const dom = new JSDOM(`
+  it('works with multiple elements', () => {
+    const { JSDOM } = jsdom;
+    const dom = new JSDOM(`
 <!DOCTYPE html>
 <html>
   <body>
@@ -72,20 +73,20 @@ it('works with multiple elements', () => {
   </body>
 </html>
   `);
-  const { document: doc } = dom.window;
-  const element = doc.querySelectorAll('button');
-  let snapshot = takeDOMSnapshot({ doc, element });
-  assert.equal(
-    snapshot.html.trim(),
-    `
+    const { document: doc } = dom.window;
+    const element = doc.querySelectorAll('button');
+    let snapshot = takeDOMSnapshot({ doc, element });
+    assert.equal(
+      snapshot.html.trim(),
+      `
   <button>Hello</button>\n<button>World</button>
   `.trim(),
-  );
-});
+    );
+  });
 
-it('works with assets', () => {
-  const { JSDOM } = jsdom;
-  const dom = new JSDOM(`
+  it('works with assets', () => {
+    const { JSDOM } = jsdom;
+    const dom = new JSDOM(`
 <!DOCTYPE html>
 <html>
   <head>
@@ -100,21 +101,21 @@ it('works with assets', () => {
   </body>
 </html>
   `);
-  const { document: doc } = dom.window;
-  const element = doc.querySelector('body');
-  let snapshot = takeDOMSnapshot({ doc, element });
-  assert.equal(snapshot.assetUrls.length, 3);
-  assert.equal(snapshot.assetUrls[0].url, '/hello.png');
-  assert.equal(snapshot.assetUrls[1].url, '/world.png');
-  assert.equal(snapshot.assetUrls[2].url, '../inside-svg.png');
-  assert.equal(snapshot.cssBlocks.length, 1);
-  assert.equal(snapshot.cssBlocks[0].href, '/foobar.css');
-  assert.equal(snapshot.cssBlocks[0].baseUrl, 'about:blank');
-});
+    const { document: doc } = dom.window;
+    const element = doc.querySelector('body');
+    let snapshot = takeDOMSnapshot({ doc, element });
+    assert.equal(snapshot.assetUrls.length, 3);
+    assert.equal(snapshot.assetUrls[0].url, '/hello.png');
+    assert.equal(snapshot.assetUrls[1].url, '/world.png');
+    assert.equal(snapshot.assetUrls[2].url, '../inside-svg.png');
+    assert.equal(snapshot.cssBlocks.length, 1);
+    assert.equal(snapshot.cssBlocks[0].href, '/foobar.css');
+    assert.equal(snapshot.cssBlocks[0].baseUrl, 'about:blank');
+  });
 
-it('works with radio and checkbox', () => {
-  const { JSDOM } = jsdom;
-  const dom = new JSDOM(`
+  it('works with radio and checkbox', () => {
+    const { JSDOM } = jsdom;
+    const dom = new JSDOM(`
 <!DOCTYPE html>
 <html>
   <body>
@@ -129,14 +130,14 @@ it('works with radio and checkbox', () => {
   </body>
 </html>
   `);
-  const { document: doc } = dom.window;
-  doc.querySelector('input[type="radio"][value="a"]').checked = true;
-  doc.querySelector('input[type="checkbox"][name="baz"]').checked = true;
-  const element = doc.querySelector('form');
-  const snapshot = takeDOMSnapshot({ doc, element });
-  assert.equal(
-    snapshot.html,
-    `
+    const { document: doc } = dom.window;
+    doc.querySelector('input[type="radio"][value="a"]').checked = true;
+    doc.querySelector('input[type="checkbox"][name="baz"]').checked = true;
+    const element = doc.querySelector('form');
+    const snapshot = takeDOMSnapshot({ doc, element });
+    assert.equal(
+      snapshot.html,
+      `
     <form>
       <input type="radio" name="foo" value="a" checked="checked">
       <input type="radio" name="foo" value="b">
@@ -146,5 +147,6 @@ it('works with radio and checkbox', () => {
       <input type="checkbox" name="car">
     </form>
   `.trim(),
-  );
+    );
+  });
 });


### PR DESCRIPTION
This reverts commit ef16a56e5c46ac607195fe8ced4e55259bafc7db.

I had misinterpreted a failure and removed these describes. It turns out that I was wrong, and we can use them after all! https://github.com/happo/happo-e2e/pull/59#issuecomment-2631231001

Thanks @cjihrig!