### PR TITLE
Localize test setup

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-export HAPPO_ENABLED=true
-export HAPPO_E2E_PORT=3000
-
 if [[ $(node -v | cut -d. -f1 | tr -d 'v') -ge 22 ]]; then
   node --test "./test/*"
 else

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -17,7 +17,15 @@ const mockHappoConfig = {
 
 const mockHappoConfigPath = path.join(__dirname, '..', '.happo.js');
 
+let originalEnv = {
+  HAPPO_ENABLED: process.env.HAPPO_ENABLED,
+  HAPPO_E2E_PORT: process.env.HAPPO_E2E_PORT,
+};
+
 before(() => {
+  process.env.HAPPO_ENABLED = true;
+  process.env.HAPPO_E2E_PORT = 3000;
+
   // Create a mock happo.js file
   fs.writeFileSync(
     mockHappoConfigPath,
@@ -26,6 +34,10 @@ before(() => {
 });
 
 after(() => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    process.env[key] = value;
+  }
+
   // Clean up the mock config
   fs.unlinkSync(mockHappoConfigPath);
 });


### PR DESCRIPTION
I wanted to run the controller test on its own, but it failed because
these env vars were set in the shell script. I started by adding a
setup.js file and importing it in all of the tests but then I realized
that we only need to do this in the controller test so I moved it there.
To make this work, we need to read the env vars lazily and not in the
module scope, so I did some light refactoring as well.

I had started to convert the tests to ESM but that ended up being a
rabbit hole of sorts and not something I need to do right now.