### PR TITLE
Handle broken CSS files when there are external assets

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -213,7 +213,7 @@ Docs:
     for (const url of uniqueUrls) {
       if (/^\/_external\//.test(url.name) && url.name !== url.url) {
         for (const block of globalCSS) {
-          block.css = block.css.split(url.url).join(url.name);
+          block.css = block.css?.split(url.url).join(url.name);
         }
         this.snapshots.forEach((snapshot) => {
           snapshot.html = snapshot.html.split(url.url).join(url.name);

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -7,8 +7,6 @@ const mime = require('mime-types');
 const makeAbsolute = require('./makeAbsolute');
 const proxiedFetch = require('./fetch');
 
-const { HAPPO_DOWNLOAD_ALL, HAPPO_DEBUG } = process.env;
-
 const FILE_CREATION_DATE = new Date('Fri March 20 2020 13:44:55 GMT+0100 (CET)');
 
 function stripQueryParams(url) {
@@ -41,6 +39,8 @@ function getFileSuffixFromMimeType(mimeType = '') {
 }
 
 module.exports = function createAssetPackage(urls) {
+  const { HAPPO_DOWNLOAD_ALL, HAPPO_DEBUG } = process.env;
+
   if (HAPPO_DEBUG) {
     console.log(`[HAPPO] Creating asset package from urls`, urls);
   }

--- a/test/controller-test.js
+++ b/test/controller-test.js
@@ -2,19 +2,12 @@ const { describe, it, before, after } = require('node:test');
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
+const http = require('http');
 const Controller = require('../controller');
 
-const mockHappoConfig = {
-  apiKey: 'test-api-key',
-  apiSecret: 'test-api-secret',
-  project: 'test-project',
-  targets: {
-    chrome: {
-      execute: async () => ['request-id-1'],
-    },
-  },
-};
+const port = 3000;
 
+let mockHappoConfig;
 const mockHappoConfigPath = path.join(__dirname, '..', '.happo.js');
 
 let originalEnv = {
@@ -22,15 +15,46 @@ let originalEnv = {
   HAPPO_E2E_PORT: process.env.HAPPO_E2E_PORT,
 };
 
+let server;
+
 before(() => {
   process.env.HAPPO_ENABLED = true;
-  process.env.HAPPO_E2E_PORT = 3000;
+  process.env.HAPPO_E2E_PORT = port;
+
+  server = http.createServer((req, res) => {
+    // Set proper headers
+    res.setHeader('Content-Type', 'application/json');
+
+    if (req.url.startsWith('/api/snap-requests/assets-data/')) {
+      res.end(
+        JSON.stringify({
+          path: '/path/to/asset',
+          uploadedAt: '2021-01-01',
+        }),
+      );
+      return;
+    }
+
+    res.end(JSON.stringify({}));
+  });
+  server.listen(port);
 
   // Create a mock happo.js file
-  fs.writeFileSync(
-    mockHappoConfigPath,
-    `module.exports = ${JSON.stringify(mockHappoConfig)}`,
-  );
+  const mockHappoConfigContents = `
+  module.exports = {
+    apiKey: 'test-api-key',
+    apiSecret: 'test-api-secret',
+    project: 'test-project',
+    endpoint: 'http://localhost:${port}',
+    targets: {
+      chrome: {
+        execute: async () => ['request-id-1'],
+      },
+    },
+  };
+  `;
+  fs.writeFileSync(mockHappoConfigPath, mockHappoConfigContents);
+  mockHappoConfig = require(mockHappoConfigPath);
 });
 
 after(() => {
@@ -40,6 +64,8 @@ after(() => {
 
   // Clean up the mock config
   fs.unlinkSync(mockHappoConfigPath);
+
+  server.close();
 });
 
 describe('Controller', () => {
@@ -52,5 +78,92 @@ describe('Controller', () => {
     assert.deepStrictEqual(controller.snapshots, []);
     assert.deepStrictEqual(controller.snapshotAssetUrls, []);
     assert.deepStrictEqual(controller.allCssBlocks, []);
+  });
+
+  it('registers snapshots', async () => {
+    const controller = new Controller();
+    await controller.init();
+
+    // Register a test snapshot
+    await controller.registerSnapshot({
+      html: '<div>Test</div>',
+      assetUrls: [{ url: 'http://example.com/asset.jpg' }],
+      component: 'Button',
+      variant: 'primary',
+      cssBlocks: [],
+    });
+
+    assert.deepStrictEqual(controller.snapshots, [
+      {
+        bodyElementAttrs: undefined,
+        component: 'Button',
+        html: '<div>Test</div>',
+        htmlElementAttrs: undefined,
+        stylesheets: [],
+        targets: ['chrome'],
+        timestamp: undefined,
+        variant: 'primary',
+      },
+    ]);
+    assert.deepStrictEqual(controller.snapshotAssetUrls, [
+      {
+        url: 'http://example.com/asset.jpg',
+      },
+    ]);
+    assert.deepStrictEqual(controller.allCssBlocks, []);
+
+    await controller.finish();
+  });
+
+  // https://github.com/happo/happo-e2e/issues/58
+  it('gracefully handles CSS files that cannot be downloaded when there are external assets', async () => {
+    const controller = new Controller();
+    await controller.init();
+
+    // Register a test snapshot
+    await controller.registerSnapshot({
+      html: '<div>Test</div>',
+      assetUrls: [
+        {
+          url: 'http://example.com/asset.jpg',
+          name: '/_external/b5d64099e230f05fdcdd447bf8db95b3',
+        },
+      ],
+      component: 'Button',
+      variant: 'primary',
+      cssBlocks: [
+        {
+          key: 'http://example.com/sheet.css',
+          href: 'http://example.com/sheet.css',
+        },
+      ],
+    });
+
+    assert.deepStrictEqual(controller.snapshots, [
+      {
+        bodyElementAttrs: undefined,
+        component: 'Button',
+        html: '<div>Test</div>',
+        htmlElementAttrs: undefined,
+        stylesheets: ['http://example.com/sheet.css'],
+        targets: ['chrome'],
+        timestamp: undefined,
+        variant: 'primary',
+      },
+    ]);
+    assert.deepStrictEqual(controller.snapshotAssetUrls, [
+      {
+        url: 'http://example.com/asset.jpg',
+        name: '/_external/b5d64099e230f05fdcdd447bf8db95b3',
+      },
+    ]);
+    assert.deepStrictEqual(controller.allCssBlocks, [
+      {
+        key: 'http://example.com/sheet.css',
+        href: 'http://example.com/sheet.css',
+      },
+    ]);
+
+    await controller.finish();
   });
 });


### PR DESCRIPTION
When there are external assets at the same time as CSS files that fail to download, the CSS file will have an undefined `.css` property. We did not guard against that here, so people in this scenario ended up running into an unhandled error.

To fix this, we just need to guard against block.css being undefined.

I was able to reproduce this in our test suite and verified that it fixes the bug.

Fixes #58