### PR TITLE
Add engines property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.3.3",
   "description": "Helpers for e2e integrations with Happo",
   "main": "index.js",
+  "engines": {
+    "node": ">=18"
+  },
   "repository": "git@github.com:happo/happo-e2e.git",
   "author": "Henric Trotzig <henric.trotzig@happo.io>",
   "license": "MIT",


### PR DESCRIPTION
We only run tests against Node 18+ in this repo, so I think it is safe to say that we only support Node 18+ here. This package also consumes happo.io which also only supports Node 18+.