### PR TITLE
Refactor createAssetPackage to use happo.io's deterministicArchive

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "serve-handler": "^6.1.5"
   },
   "dependencies": {
-    "archiver": "^7.0.1",
     "async-retry": "^1.3.3",
     "base64-stream": "^1.0.0",
     "crypto-js": "^4.1.1",

--- a/test/createAssetPackage-test.js
+++ b/test/createAssetPackage-test.js
@@ -45,13 +45,18 @@ describe('createAssetPackage', () => {
       },
     ]);
 
-    assert.equal(pkg.hash, '898862aad00d429b73f57256332a6ee1');
+    assert.equal(pkg.hash, '8cdd63709442c4f37034425715630055');
 
     const zip = new AdmZip(pkg.buffer);
     const entries = zip.getEntries();
     assert.equal(entries.length, 3);
-    assert.equal(entries[0].name, 'countries-bg.jpeg');
-    assert.equal(entries[1].name, '8f037ef4cc4efb6ab6df9cc5d88f7898.jpeg');
-    assert.equal(entries[2].name, 'a0f415163499472aab9e93339b832d12.html');
+    assert.deepEqual(
+      entries.map((e) => e.name),
+      [
+        '8f037ef4cc4efb6ab6df9cc5d88f7898.jpeg',
+        'a0f415163499472aab9e93339b832d12.html',
+        'countries-bg.jpeg',
+      ],
+    );
   });
 });


### PR DESCRIPTION
This is how we create archives elsewhere, so we might as well build on top of it.

One improvement with this method is it enables zlib compression at level 6, which in my tests seems to reduce the size of asset packages by about 14%. That is one reach the package hash in the tests changed.