### PR TITLE
Add test-results to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@ run-tests.sh
 test
 test-fixtures
 test-package.zip
+test-results


### PR DESCRIPTION
I found that we might publish files here by running:

```sh
npm pack --dry-run
```