### PR TITLE
Import postGithubComment from build, not src

### DIFF
--- a/bin/happo-e2e.js
+++ b/bin/happo-e2e.js
@@ -8,7 +8,7 @@ const yargs = require('yargs/yargs');
 
 const makeRequest = require('happo.io/build/makeRequest').default;
 const compareReports = require('happo.io/build/commands/compareReports').default;
-const postGithubComment = require('happo.io/src/postGithubComment').default;
+const postGithubComment = require('happo.io/build/postGithubComment').default;
 
 const loadHappoConfig = require('../src/loadHappoConfig');
 const resolveEnvironment = require('../src/resolveEnvironment');


### PR DESCRIPTION
This will fix a bug where `import` is not valid syntax in CommonJS. Obviously we could benefit from better test coverage here. I'll follow up with that soon.