### PR TITLE
Add first test for bin/happo-e2e.js

### DIFF
--- a/bin/happo-e2e.js
+++ b/bin/happo-e2e.js
@@ -270,7 +270,17 @@ async function init(argv) {
   });
 }
 
-init(hideBin(process.argv)).catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+async function main(argv) {
+  try {
+    await init(hideBin(argv));
+  } catch (e) {
+    console.error(e);
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main(process.argv);
+}
+
+module.exports = main;

--- a/test/happo-e2e-test.js
+++ b/test/happo-e2e-test.js
@@ -1,0 +1,34 @@
+const { describe, it, before, after } = require('node:test');
+const path = require('node:path');
+const os = require('node:os');
+const assert = require('node:assert');
+const fs = require('node:fs');
+
+const happoE2E = require('../bin/happo-e2e');
+
+const tmpHappoConfig = path.join(os.tmpdir(), '.happo.js');
+before(() => {
+  process.env.HAPPO_CONFIG_FILE = tmpHappoConfig;
+});
+
+after(() => {
+  fs.unlinkSync(tmpHappoConfig);
+  process.exitCode = undefined;
+});
+
+function writeHappoConfig(config) {
+  fs.writeFileSync(
+    tmpHappoConfig,
+    `module.exports = ${JSON.stringify(config, null, 2)}`,
+  );
+}
+
+describe('finalize command', () => {
+  it('exits with code 1 if apiKey is not set', async () => {
+    writeHappoConfig({});
+
+    await happoE2E(['happo-e2e', '--', 'finalize']);
+
+    assert.strictEqual(process.exitCode, 1);
+  });
+});


### PR DESCRIPTION
We recently shipped a bug with an incorrect import statement. This should have been caught by any test running on this file but we did not have any.

I am getting the ball rolling here by writing a very basic test on this file. To make this bin script importable and executable as a function, I am doing some light refactoring at the same time.

We should definitely come back and add more testing, but for now this is a great improvement.