### PR TITLE
Add monkey-patch for constructed styles

### DIFF
--- a/playwright-tests/takeDOMSnapshot.test.js
+++ b/playwright-tests/takeDOMSnapshot.test.js
@@ -242,12 +242,24 @@ test('constructed styles', async ({ page }) => {
     });
 
     expect(snapshot.html).toMatch(/<p>world<\/p>/s);
-    expect(snapshot.cssBlocks.length).toBe(2);
+    expect(snapshot.html).toContain(
+      'CSSStyleSheet.prototype.deleteRule does not work with Happo',
+    );
+    expect(snapshot.cssBlocks.length).toBe(4);
     expect(snapshot.cssBlocks[0].content.replace(/\s+/g, ' ').trim()).toEqual(
       'p { color: blue; }',
     );
     expect(snapshot.cssBlocks[1].content.replace(/\s+/g, ' ')).toEqual(
-      'p { color: red; }',
+      'b { color: green; } :root { --my-custom-font: 400 1rem / 1.5rem Roboto; --my-custom-font-weight: 400; } p { font: var(--my-custom-font); font-weight: var(--my-custom-font-weight); }',
+    );
+    expect(snapshot.cssBlocks[2].content.replace(/\s+/g, ' ')).toEqual(
+      'b { color: violet; }',
+    );
+    expect(snapshot.cssBlocks[3].content.replace(/\s+/g, ' ')).toEqual(
+      ':root { --my-custom-font: 600 1em / 1em Comic; --my-custom-font-weight: 400; } p { font: var(--my-custom-font); font-weight: var(--my-custom-font-weight); }',
+    );
+    expect(snapshot.cssBlocks.map((block) => block.content).join(' ')).not.toMatch(
+      /color: ?red/,
     );
   }
 
@@ -258,12 +270,21 @@ test('constructed styles', async ({ page }) => {
     });
 
     expect(snapshot.html).toMatch(/<h1>Hello<\/h1>/s);
-    expect(snapshot.cssBlocks.length).toBe(2);
+    expect(snapshot.cssBlocks.length).toBe(4);
     expect(snapshot.cssBlocks[0].content.replace(/\s+/g, ' ').trim()).toEqual(
       'p { color: blue; }',
     );
     expect(snapshot.cssBlocks[1].content.replace(/\s+/g, ' ')).toEqual(
-      'p { color: red; }',
+      'b { color: green; } :root { --my-custom-font: 400 1rem / 1.5rem Roboto; --my-custom-font-weight: 400; } p { font: var(--my-custom-font); font-weight: var(--my-custom-font-weight); }',
+    );
+    expect(snapshot.cssBlocks[2].content.replace(/\s+/g, ' ')).toEqual(
+      'b { color: violet; }',
+    );
+    expect(snapshot.cssBlocks[3].content.replace(/\s+/g, ' ')).toEqual(
+      ':root { --my-custom-font: 600 1em / 1em Comic; --my-custom-font-weight: 400; } p { font: var(--my-custom-font); font-weight: var(--my-custom-font-weight); }',
+    );
+    expect(snapshot.cssBlocks.map((block) => block.content).join(' ')).not.toMatch(
+      /color: ?red/,
     );
   }
 });

--- a/playwright-tests/test-assets/constructed-styles/index.js
+++ b/playwright-tests/test-assets/constructed-styles/index.js
@@ -1,10 +1,50 @@
-// Create a new constructed stylesheet
-const sheet = new CSSStyleSheet();
-sheet.replaceSync(`
+// Create a new constructed stylesheet that uses insertRule and deleteRule.
+const injectSheet = new CSSStyleSheet();
+injectSheet.insertRule(
+  `
+  :root {
+    --my-custom-font: 400 1rem / 1.5rem Roboto;
+    --my-custom-font-weight: 400;
+  }`,
+  0,
+);
+injectSheet.insertRule(
+  `
   p {
-    color: red;
-  }
-`);
+    font: var(--my-custom-font);
+    font-weight: var(--my-custom-font-weight);
+  }`,
+  1,
+);
+injectSheet.insertRule('b { color: green; }'); // This will go to the top
+injectSheet.insertRule('i { color: red; }', 1);
+injectSheet.deleteRule(1); // Remove "i { color: red; }"
+document.adoptedStyleSheets.push(injectSheet);
 
-// Apply the constructed stylesheet to the document
-document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+// Create a new constructed stylesheet that uses replaceSync.
+const replaceSyncSheet = new CSSStyleSheet();
+replaceSyncSheet.insertRule('i { color: red; }', 0);
+replaceSyncSheet.replaceSync('b { color: violet; }');
+replaceSyncSheet.deleteRule(0);
+document.adoptedStyleSheets.push(replaceSyncSheet);
+
+// Create a new constructed stylesheet that uses async replace.
+const replaceSheet = new CSSStyleSheet();
+replaceSheet.addRule('i', 'color: red;');
+replaceSheet
+  .replace(
+    `
+  :root {
+    --my-custom-font: 600 1em / 1em Comic;
+    --my-custom-font-weight: 400;
+  }
+  p {
+    font: var(--my-custom-font);
+    font-weight: var(--my-custom-font-weight);
+  }
+  `,
+  )
+  .then(() => {
+    // Apply the constructed stylesheet to the document
+    document.adoptedStyleSheets.push(replaceSheet);
+  });

--- a/src/applyConstructedStylesPatch.js
+++ b/src/applyConstructedStylesPatch.js
@@ -1,0 +1,134 @@
+const recordedCSSSymbol = Symbol('recordedCssRules');
+const hasBrokenIndexesSymbol = Symbol('hasBrokenIndexes');
+
+// Helper to ensure our custom recorded array exists on the sheet.
+function ensureRecord(sheet) {
+  if (!sheet[recordedCSSSymbol]) {
+    sheet[recordedCSSSymbol] = [];
+  }
+}
+
+function displayError(message) {
+  console.error(message);
+
+  const el = document.createElement('div');
+  el.setAttribute(
+    'style',
+    `
+    position: fixed;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    padding: 30px;
+    background: red;
+    font-weight: bold;
+    color: white;
+    z-index: 1000;
+    font-family: monospace;
+  `,
+  );
+  const inner = document.createElement('div');
+  inner.textContent = message;
+  el.appendChild(inner);
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.appendChild(el);
+  });
+}
+
+module.exports = function applyConstructedStylesPatch() {
+  if (typeof CSSStyleSheet === 'undefined') {
+    console.error('CSSStyleSheet is not supported in this browser');
+    return;
+  }
+  // Patch insertRule to record each rule string.
+  const originalInsertRule = CSSStyleSheet.prototype.insertRule;
+  CSSStyleSheet.prototype.insertRule = function (rule, index = 0) {
+    ensureRecord(this);
+
+    if (this[hasBrokenIndexesSymbol] && index) {
+      displayError(
+        'CSSStyleSheet.prototype.insertRule with a non-zero index does not work with Happo after first having called replace/replaceSync. Reach out to support@happo.io if you need help with this.',
+      );
+      return originalInsertRule.call(this, rule, index);
+    }
+
+    // If index is not provided or invalid, default to appending.
+    if (index === undefined || index < 0 || index > this[recordedCSSSymbol].length) {
+      this[recordedCSSSymbol].push(rule);
+    } else {
+      this[recordedCSSSymbol].splice(index, 0, rule);
+    }
+    return originalInsertRule.call(this, rule, index);
+  };
+
+  const originalAddRule = CSSStyleSheet.prototype.addRule;
+  CSSStyleSheet.prototype.addRule = function (selector, styleBlock, index) {
+    ensureRecord(this);
+    if (this[hasBrokenIndexesSymbol] && index) {
+      displayError(
+        'CSSStyleSheet.prototype.addRule with a non-zero index does not work with Happo after first having called replace/replaceSync. Reach out to support@happo.io if you need help with this.',
+      );
+      return originalAddRule.call(this, selector, styleBlock, index);
+    }
+
+    const rule = `${selector} { ${styleBlock} }`;
+    if (index === undefined || index < 0 || index > this[recordedCSSSymbol].length) {
+      this[recordedCSSSymbol].push(rule);
+    } else {
+      this[recordedCSSSymbol].splice(index, 0, rule);
+    }
+    return originalAddRule.call(this, selector, styleBlock, index);
+  };
+
+  // Patch deleteRule so that removed rules are taken out of our record.
+  const originalDeleteRule = CSSStyleSheet.prototype.deleteRule;
+  CSSStyleSheet.prototype.deleteRule = function (index) {
+    ensureRecord(this);
+    if (this[hasBrokenIndexesSymbol]) {
+      displayError(
+        'CSSStyleSheet.prototype.deleteRule does not work with Happo after first having called replace/replaceSync. Reach out to support@happo.io if you need help with this.',
+      );
+    } else if (index >= 0 && index < this[recordedCSSSymbol].length) {
+      this[recordedCSSSymbol].splice(index, 1);
+    }
+    return originalDeleteRule.call(this, index);
+  };
+
+  const originalRemoveRule = CSSStyleSheet.prototype.removeRule;
+  CSSStyleSheet.prototype.removeRule = function (index) {
+    ensureRecord(this);
+    if (this[hasBrokenIndexesSymbol]) {
+      displayError(
+        'CSSStyleSheet.prototype.removeRule does not work with Happo after first having called replace/replaceSync. Reach out to support@happo.io if you need help with this.',
+      );
+    } else if (index >= 0 && index < this[recordedCSSSymbol].length) {
+      this[recordedCSSSymbol].splice(index, 1);
+    }
+    return originalRemoveRule.call(this, index);
+  };
+
+  // Patch replaceSync to capture the new CSS text.
+  const originalReplaceSync = CSSStyleSheet.prototype.replaceSync;
+  CSSStyleSheet.prototype.replaceSync = function (text) {
+    this[recordedCSSSymbol] = text.split('\n').map((rule) => rule.trim());
+    this[hasBrokenIndexesSymbol] = true;
+    return originalReplaceSync.call(this, text);
+  };
+
+  // Patch replace (the asynchronous version) similarly.
+  const originalReplace = CSSStyleSheet.prototype.replace;
+  CSSStyleSheet.prototype.replace = function (text) {
+    const sheet = this;
+    return originalReplace.call(sheet, text).then(function (result) {
+      sheet[recordedCSSSymbol] = text.split('\n').map((rule) => rule.trim());
+      sheet[hasBrokenIndexesSymbol] = true;
+      return result;
+    });
+  };
+};
+
+module.exports.recordedCSSSymbol = recordedCSSSymbol;

--- a/takeDOMSnapshot.js
+++ b/takeDOMSnapshot.js
@@ -2,9 +2,13 @@ const md5 = require('crypto-js/md5');
 const parseSrcset = require('parse-srcset');
 
 const findCSSAssetUrls = require('./src/findCSSAssetUrls');
+const applyConstructedStylesPatch = require('./src/applyConstructedStylesPatch');
 
 const CSS_ELEMENTS_SELECTOR = 'style,link[rel="stylesheet"][href]';
 const COMMENT_PATTERN = /^\/\*.+\*\/$/;
+
+applyConstructedStylesPatch();
+const recordedCSSSymbol = applyConstructedStylesPatch.recordedCSSSymbol;
 
 function getContentFromStyleSheet(element) {
   let lines;
@@ -12,6 +16,8 @@ function getContentFromStyleSheet(element) {
   if (element.textContent) {
     // Handle <style> elements with direct textContent
     lines = element.textContent.split('\n').map((line) => line.trim());
+  } else if (element[recordedCSSSymbol]) {
+    lines = element[recordedCSSSymbol];
   } else if (element.sheet?.cssRules) {
     // Handle <style> or <link> elements that have a sheet property
     lines = Array.from(element.sheet.cssRules).map((rule) => rule.cssText);


### PR DESCRIPTION
We know that using shorthand values with variables can lead to issues with the DOM snapshot. For instance,

p {
  font: var(--font);
  font-weight: var(--font-weight);
}

becomes

p {
  font-family: ;
  font-weight: ;
  font-size: ;
  ... etc
}

See:
https://issues.chromium.org/issues/40905071#comment7 https://issues.chromium.org/issues/40240778#comment5

We can fix this by monkey-patching CSSStyleSheet and its functions. By recording the strings exactly as they are injected, we can preserve the "real" css that the user intended to apply.