### PR TITLE
Allow applyConstructedStylesPatch to take a window argument, expose as takeDOMSnapshot.applyConstructedStylesPatch()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     cy: 'readonly',
     describe: 'readonly',
     it: 'readonly',
+    globalThis: 'readonly',
   },
   ignorePatterns: ['pages/'],
   parserOptions: {

--- a/takeDOMSnapshot.js
+++ b/takeDOMSnapshot.js
@@ -393,10 +393,13 @@ function takeDOMSnapshot({
     bodyElementAttrs,
   };
 }
+
 takeDOMSnapshot.init = function noop() {
   // There used to be some code in here to set the baseUrl of all link elements.
   // But that's no longer needed (because Node.baseURI exists). We're keeping
   // the function around here however to make sure we stay backwards compatible.
 };
+
+takeDOMSnapshot.applyConstructedStylesPatch = applyConstructedStylesPatch;
 
 module.exports = takeDOMSnapshot;


### PR DESCRIPTION
We want this patch to work in Cypress, where the page is rendered in an iframe and we need to run our patch on a different `window`. To make this work, happo-e2e needs to expose the patch function in a way that it can be applied to a different `window`, so we are adding a window argument to the function. It defaults to `window`, so it will continue working for the current use cases just fine.

Cypress needs to call this function in its own special Cypress way, so we are adding a property to takeDOMSnapshot to make importing it easier and backwards compatible.