### PR TITLE
Avoid using optional chaining operators

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -172,7 +172,9 @@ Docs:
     for (const url of uniqueUrls) {
       if (/^\/_external\//.test(url.name) && url.name !== url.url) {
         for (const block of globalCSS) {
-          block.css = block.css?.split(url.url).join(url.name);
+          block.css = block.css
+            ? block.css.split(url.url).join(url.name)
+            : undefined;
         }
         this.snapshots.forEach((snapshot) => {
           snapshot.html = snapshot.html.split(url.url).join(url.name);

--- a/takeDOMSnapshot.js
+++ b/takeDOMSnapshot.js
@@ -18,7 +18,7 @@ function getContentFromStyleSheet(element) {
     lines = element.textContent.split('\n').map((line) => line.trim());
   } else if (element[recordedCSSSymbol]) {
     lines = element[recordedCSSSymbol];
-  } else if (element.sheet?.cssRules) {
+  } else if (element.sheet && element.sheet.cssRules) {
     // Handle <style> or <link> elements that have a sheet property
     lines = Array.from(element.sheet.cssRules).map((rule) => rule.cssText);
   } else if (element.cssRules) {


### PR DESCRIPTION
We just had a report of someone trying to use the latest happo-e2e but ending up with module parse errors:

Module parse failed: Unexpected token (21:27)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|   } else if (element[recordedCSSSymbol]) {
|     lines = element[recordedCSSSymbol];
>   } else if (element.sheet?.cssRules) {
|     // Handle <style> or <link> elements that have a sheet property
|     lines = Array.from(element.sheet.cssRules).map((rule) => rule.cssText);

I suspect this is because they are using a node version older than v14 (when optional chaining operators were introduced). It could be that it's caused by the node.js version bundled with Cypress (they are on Cypress v12.7).