### PR TITLE
Lint against syntax that is invalid in webpack v4

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,20 @@ module.exports = {
   },
   rules: {
     'no-use-before-define': 2,
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ChainExpression',
+        message: 'Optional chaining (?.) is not supported in Webpack 4',
+      },
+      {
+        selector: 'LogicalExpression[operator="??"]',
+        message: 'Nullish coalescing operator (??) is not supported in Webpack 4',
+      },
+      {
+        selector: 'ClassProperty',
+        message: 'Class fields are not supported in Webpack 4',
+      },
+    ],
   },
 };


### PR DESCRIPTION
I asked cursor to update the eslint config so that we catch constructs that use syntax not recognized by webpack 4.

This type of linting would have prevented an issue where one of our users ran into a parse error coming from takeDOMSnapshot related to optional chaining, `element.sheet?.cssRules`.

Fixes https://linear.app/happo/issue/HAP-274/lint-against-syntax-that-is-invalid-in-webpack-v4