### PR TITLE
Replace node-fetch with built-in fetch

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -1,7 +1,6 @@
 const crypto = require('crypto');
 const fs = require('fs');
 
-const nodeFetch = require('node-fetch');
 const imageSize = require('image-size');
 const pAll = require('p-all');
 const { RemoteBrowserTarget } = require('happo.io');
@@ -351,7 +350,7 @@ Docs:
 
     if (HAPPO_E2E_PORT) {
       // We're running with `happo-cypress --`
-      const fetchRes = await nodeFetch(`http://localhost:${HAPPO_E2E_PORT}/`, {
+      const fetchRes = await fetch(`http://localhost:${HAPPO_E2E_PORT}/`, {
         method: 'POST',
         body: allRequestIds.join('\n'),
       });

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "https-proxy-agent": "^5.0.0",
     "image-size": "^1.0.1",
     "mime-types": "^2.1.35",
-    "node-fetch": "^2.0.0",
     "p-all": "^3.0.0",
     "parse-srcset": "^1.0.2",
     "yargs": "^17.7.2"

--- a/src/createAssetPackage.js
+++ b/src/createAssetPackage.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const { Readable } = require('stream');
 
 const mime = require('mime-types');
 const deterministicArchive = require('happo.io/build/deterministicArchive').default;
@@ -104,7 +105,7 @@ module.exports = async function createAssetPackage(urls) {
 
           archiveContent.push({
             name,
-            content: fetchRes.body,
+            content: Readable.fromWeb(fetchRes.body),
           });
         } catch (e) {
           console.log(`[HAPPO] Failed to fetch url ${fetchUrl}`);

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,4 +1,3 @@
-const nodeFetch = require('node-fetch');
 const HttpsProxyAgent = require('https-proxy-agent');
 const asyncRetry = require('async-retry');
 
@@ -9,13 +8,13 @@ if (HTTP_PROXY) {
   fetchOptions.agent = new HttpsProxyAgent(HTTP_PROXY);
 }
 if (HAPPO_DEBUG) {
-  console.log(`[HAPPO] using the following node-fetch options`, fetchOptions);
+  console.log(`[HAPPO] using the following fetch options`, fetchOptions);
 }
 
-module.exports = async function fetch(url, { retryCount = 0 }) {
+module.exports = async function happoFetch(url, { retryCount = 0 }) {
   return asyncRetry(
     async (bail) => {
-      const response = await nodeFetch(url, fetchOptions);
+      const response = await fetch(url, fetchOptions);
 
       if (response.status >= 400 && response.status < 500) {
         bail(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,7 +2237,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-node-fetch@^2.0.0, node-fetch@^2.6.6:
+node-fetch@^2.6.6:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
Node added fetch in v17.5, and we don't support anything older than Node 18, so we should be able to remove this dependency now without any issues.