### PR TITLE
Strip UTF-8 BOM when downloading CSS files

### DIFF
--- a/controller.js
+++ b/controller.js
@@ -61,6 +61,14 @@ async function downloadCSSContent(blocks) {
         );
       }
 
+      // Strip UTF-8 BOM character if present
+      if (text.charCodeAt(0) === 0xfeff) {
+        text = text.slice(1);
+        if (HAPPO_DEBUG) {
+          console.log(`[HAPPO] Stripped UTF-8 BOM from CSS file ${absUrl}`);
+        }
+      }
+
       if (!absUrl.startsWith(block.baseUrl)) {
         text = makeExternalUrlsAbsolute(text, absUrl);
       }


### PR DESCRIPTION
If the file contains a Byte Order Mark character, it will break the style when it is rendered on the workers. We need to remove this character to fix this problem.