### PR TITLE
Add automerge GitHub workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,21 @@
+name: Automerge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v3
+        with:
+          merge-method: 'merge'
+          target: 'minor'
+          use-github-auto-merge: true


### PR DESCRIPTION
This will automerge dependabot PRs which will reduce the amount of time we spend maintaining this repo.